### PR TITLE
Get token of GitHub using OAuth App

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ uuid = { version = "1.1.2", features = ["v4"] }
 walkdir = "2.3.2"
 
 # Networking
+oauth2 = { version = "4.2.3", features = ["ureq"], default-features = false }
 ureq = { version = "2.5.0", features = ["json"] }
 url = "2.2.2"
 

--- a/src/distribution/auth/github.rs
+++ b/src/distribution/auth/github.rs
@@ -1,0 +1,18 @@
+use crate::error::*;
+use oauth2::{basic::BasicClient, AuthUrl, ClientId, DeviceAuthorizationUrl, TokenUrl};
+
+pub fn get_token() -> Result<String> {
+    // "ocipkg" GitHub OAuth App
+    // https://github.com/settings/applications/1952947
+    let _client = BasicClient::new(
+        ClientId::new("d9ec21750789e17a0c5c".to_string()),
+        None,
+        AuthUrl::new("https://github.com/login/oauth/authorize".to_string()).unwrap(),
+        Some(TokenUrl::new("https://github.com/login/oauth/access_token".to_string()).unwrap()),
+    )
+    .set_device_authorization_url(
+        DeviceAuthorizationUrl::new("https://github.com/login/device/code".to_string()).unwrap(),
+    );
+
+    todo!()
+}

--- a/src/distribution/auth/mod.rs
+++ b/src/distribution/auth/mod.rs
@@ -1,0 +1,1 @@
+pub mod github;

--- a/src/distribution/mod.rs
+++ b/src/distribution/mod.rs
@@ -1,5 +1,7 @@
 //! Pull and Push images to OCI registry based on [OCI distribution specification](https://github.com/opencontainers/distribution-spec)
 
+pub mod auth;
+
 mod client;
 mod name;
 mod reference;


### PR DESCRIPTION
Resolve #18 

By getting GitHub token using [device flow](https://docs.github.com/en/developers/apps/building-oauth-apps/authorizing-oauth-apps#device-flow)