### PR TITLE
Revise error handling with ureq

### DIFF
--- a/src/distribution/client.rs
+++ b/src/distribution/client.rs
@@ -150,7 +150,7 @@ impl CheckResponse for std::result::Result<ureq::Response, ureq::Error> {
                 let err = res.into_json::<ErrorResponse>()?;
                 Err(Error::RegistryError(err))
             }
-            Err(ureq::Error::Transport(e)) => Err(Error::NetworkError3(e)),
+            Err(ureq::Error::Transport(e)) => Err(Error::NetworkError(e)),
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -42,9 +42,7 @@ pub enum Error {
     // Error from OCI registry
     //
     #[error(transparent)]
-    NetworkError(#[from] ureq::Error),
-    #[error(transparent)]
-    NetworkError3(#[from] ureq::Transport),
+    NetworkError(#[from] ureq::Transport),
     #[error(transparent)]
     RegistryError(#[from] oci_spec::distribution::ErrorResponse),
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -44,6 +44,8 @@ pub enum Error {
     #[error(transparent)]
     NetworkError(#[from] ureq::Error),
     #[error(transparent)]
+    NetworkError3(#[from] ureq::Transport),
+    #[error(transparent)]
     RegistryError(#[from] oci_spec::distribution::ErrorResponse),
 
     //


### PR DESCRIPTION
`ureq::Response::call` maps status error (e.g. 401 HTTP status) to `ureq::Error::Status` enum.