### PR TITLE
`cargo ocipkg publish` subcommand

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -17,11 +17,13 @@ jobs:
         args: --features=cli --path=. -f
     - name: Add path
       run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-    - name: Build container with cargo-ocipkg
+
+    - name: Build and publish a container with cargo-ocipkg
       run: |
         cd examples/rust-lib
-        cargo ocipkg build -t ghcr.io/termoshtt/ocipkg/rust-lib:latest
-        podman load < ./target/debug/ocipkg-lib-example.tar
+        ocipkg login -u ${{ github.repository_owner }} -p ${{ github.token }} https://ghcr.io
+        cargo ocipkg build
+        cargo ocipkg publish
 
   rust-exe:
     runs-on: ubuntu-22.04
@@ -38,7 +40,7 @@ jobs:
       run: |
         cd examples/rust-lib
         cargo ocipkg build -t ghcr.io/termoshtt/ocipkg/rust-lib:latest
-        ocipkg load ./target/debug/ocipkg-lib-example.tar
+        ocipkg load $(find . -name "ocipkg_*.tar")
 
     - name: Build rust-exe example
       run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 
 [features]
 default = []
-cli = ["clap", "cargo_metadata", "env_logger", "git2"]
+cli = ["clap", "cargo_metadata", "env_logger", "git2", "colored"]
 
 [dependencies]
 base16ct = { version = "0.1.1", features = ["alloc"] }
@@ -34,6 +34,7 @@ cargo_metadata = { version = "0.15.0", optional = true }
 clap = { version = "3.2.8", optional = true, features = ["derive"] }
 env_logger = { version = "0.9.0", optional = true }
 git2 = { version = "0.14.4", optional = true }
+colored = { version = "2.0.0", optional = true }
 
 [[bin]]
 name = "ocipkg"

--- a/src/bin/cargo-ocipkg.rs
+++ b/src/bin/cargo-ocipkg.rs
@@ -1,8 +1,11 @@
 use cargo_metadata::{Metadata, MetadataCommand, Package};
 use clap::{Parser, Subcommand};
+use colored::Colorize;
 use ocipkg::{error::*, ImageName};
 use std::{
+    collections::hash_map::DefaultHasher,
     fs,
+    hash::{Hash, Hasher},
     path::{Path, PathBuf},
     process::Command,
 };
@@ -28,6 +31,7 @@ enum Ocipkg {
         tag: Option<String>,
     },
 
+    /// Publish container to OCI registry
     Publish {
         #[clap(short = 'p', long = "package-name")]
         package_name: Option<String>,
@@ -122,6 +126,17 @@ fn generate_image_name(package: &Package) -> ImageName {
     }
 }
 
+fn generate_oci_archive_filename(
+    image_name: &ImageName,
+    target: &cargo_metadata::Target,
+) -> String {
+    let mut hasher = DefaultHasher::new();
+    image_name.hash(&mut hasher);
+    target.hash(&mut hasher);
+    let hash = hasher.finish();
+    format!("ocipkg_{:x}.tar", hash)
+}
+
 fn main() -> Result<()> {
     env_logger::Builder::new()
         .filter_level(log::LevelFilter::Info)
@@ -153,7 +168,7 @@ fn main() -> Result<()> {
 
             for target in package.targets {
                 let mut targets = Vec::new();
-                for ty in target.crate_types {
+                for ty in &target.crate_types {
                     // FIXME support non-Linux OS
                     match ty.as_str() {
                         "staticlib" => {
@@ -169,12 +184,16 @@ fn main() -> Result<()> {
                         _ => {}
                     }
                 }
-
                 if targets.is_empty() {
                     panic!("No target exists for packing. Only staticlib or cdylib are suppoted.");
                 }
 
-                let dest = build_dir.join(format!("{}.tar", target.name));
+                let dest = build_dir.join(generate_oci_archive_filename(&image_name, &target));
+                eprintln!(
+                    "{:>12} oci-archive ({})",
+                    "Creating".green().bold(),
+                    dest.display()
+                );
                 let f = fs::File::create(dest)?;
                 let mut b = ocipkg::image::Builder::new(f);
                 b.set_name(&image_name);
@@ -192,11 +211,15 @@ fn main() -> Result<()> {
             let build_dir = get_build_dir(&metadata, release);
             let image_name = generate_image_name(&package);
             for target in package.targets {
-                let dest = build_dir.join(format!("{}.tar", target.name));
+                let dest = build_dir.join(generate_oci_archive_filename(&image_name, &target));
                 if !dest.exists() {
                     panic!("OCI archive not found: {}", dest.display());
                 }
-                log::info!("Publish {}", image_name);
+                eprintln!(
+                    "{:>12} container ({})",
+                    "Publish".green().bold(),
+                    image_name
+                );
                 ocipkg::distribution::push_image(&dest)?;
             }
         }

--- a/src/bin/cargo-ocipkg.rs
+++ b/src/bin/cargo-ocipkg.rs
@@ -79,7 +79,10 @@ fn get_revision(manifest_path: &Path) -> String {
     let rev = repo
         .revparse_single("HEAD")
         .expect("git rev-parse returns unexptected value");
-    rev.id().to_string()
+    let mut hash = rev.id().to_string();
+    // Default length of `git rev-parse --short`
+    hash.truncate(7);
+    hash
 }
 
 fn generate_image_name(package: &Package) -> ImageName {

--- a/src/distribution/client.rs
+++ b/src/distribution/client.rs
@@ -107,9 +107,10 @@ impl Client {
             .set("Content-Type", &MediaType::ImageManifest.to_string())
             .send_bytes(&buf)
             .check_response()?;
-        Ok(Url::parse(res.header("Location").expect(
-            "Location header is lacked in OCI registry response",
-        ))?)
+        let loc = res
+            .header("Location")
+            .expect("Location header is lacked in OCI registry response");
+        Ok(Url::parse(loc).or_else(|_| self.url.join(loc))?)
     }
 
     /// Get blob for given digest
@@ -143,10 +144,10 @@ impl Client {
             .url
             .join(&format!("/v2/{}/blobs/uploads/", self.name))?;
         let res = self.post(&url).call().check_response()?;
-        let url = Url::parse(
-            res.header("Location")
-                .expect("Location header is lacked in OCI registry response"),
-        )?;
+        let loc = res
+            .header("Location")
+            .expect("Location header is lacked in OCI registry response");
+        let url = Url::parse(loc).or_else(|_| self.url.join(loc))?;
 
         let digest = Digest::from_buf_sha256(blob);
         let res = self
@@ -156,9 +157,10 @@ impl Client {
             .set("Content-Type", "application/octet-stream")
             .send_bytes(blob)
             .check_response()?;
-        Ok(Url::parse(res.header("Location").expect(
-            "Location header is lacked in OCI registry response",
-        ))?)
+        let loc = res
+            .header("Location")
+            .expect("Location header is lacked in OCI registry response");
+        Ok(Url::parse(loc).or_else(|_| self.url.join(loc))?)
     }
 }
 


### PR DESCRIPTION
We can publish a container to ghcr.io using `cargo-ocipkg` :rocket: 