### PR TITLE
Make vergen dependency optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ In addition to original Keep-a-Changelog, we use following rules:
 ### Changed
 
 ### Fixed
+- Make vergen build-dependency optional https://github.com/termoshtt/ocipkg/pull/63
 
 ### Internal
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/termoshtt/ocipkg"
 
 [features]
 default = []
-cli = ["clap", "clap-vergen", "cargo_metadata", "env_logger", "git2", "colored"]
+cli = ["clap", "clap-vergen", "vergen", "cargo_metadata", "env_logger", "git2", "colored"]
 
 [dependencies]
 base16ct = { version = "0.1.1", features = ["alloc"] }
@@ -53,5 +53,6 @@ required-features = ["cli"]
 [dev-dependencies]
 maplit = "1.0.2"
 
-[build-dependencies]
-vergen = "7.3.2"
+[build-dependencies.vergen]
+version = "7.3.2"
+optional = true

--- a/build.rs
+++ b/build.rs
@@ -1,7 +1,11 @@
+#[cfg(feature = "cli")]
 use vergen::{vergen, Config};
 
 fn main() {
-    let mut cfg = Config::default();
-    *cfg.sysinfo_mut().name_mut() = false;
-    vergen(cfg).expect("Fail to generate version info");
+    #[cfg(feature = "cli")]
+    {
+        let mut cfg = Config::default();
+        *cfg.sysinfo_mut().name_mut() = false;
+        vergen(cfg).expect("Fail to generate version info");
+    }
 }


### PR DESCRIPTION
Hot fix of 0.1.1, which has been yanked