### PR TITLE
Fallback to use `~/.ocipkg/config.json`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ In addition to original Keep-a-Changelog, we use following rules:
 ### Added
 
 ### Changed
+- Fallback to use ~/.ocipkg/config.json if XDG_RUNTIME_DIR not set https://github.com/termoshtt/ocipkg/pull/67
 
 ### Fixed
 

--- a/ocipkg/src/distribution/auth.rs
+++ b/ocipkg/src/distribution/auth.rs
@@ -125,8 +125,14 @@ struct Auth {
 }
 
 fn auth_path() -> Option<PathBuf> {
-    let dirs = directories::ProjectDirs::from("", "", "ocipkg")?;
-    Some(dirs.runtime_dir()?.join("auth.json"))
+    directories::ProjectDirs::from("", "", "ocipkg")
+        .and_then(|dirs| Some(dirs.runtime_dir()?.join("auth.json")))
+        .or_else(|| {
+            // Most of container does not set XDG_RUNTIME_DIR,
+            // and then this fallback to `~/.ocipkg/config.json` like docker.
+            let dirs = directories::BaseDirs::new()?;
+            Some(dirs.home_dir().join(".ocipkg/config.json"))
+        })
 }
 
 fn docker_auth_path() -> Option<PathBuf> {


### PR DESCRIPTION
`XDG_RUNTIME_DIR` is set by pam-systemd, but most container does not start systemd.