### PR TITLE
Pin `git2` dependency to 0.14.2

### DIFF
--- a/ocipkg-cli/Cargo.toml
+++ b/ocipkg-cli/Cargo.toml
@@ -16,7 +16,8 @@ cargo_metadata = "0.15.0"
 clap = { version = "3.2.8", features = ["derive"] }
 colored = "2.0.0"
 env_logger = "0.9.0"
-git2 = "0.13.25"
+# Pinned because newer versions require Rust 1.60 while this crate has a MSRV of 1.57
+git2 = "=0.14.2"
 log = "0.4.17"
 serde_json = "1.0.82"
 url = "2.2.2"


### PR DESCRIPTION
In order to maintain a MSRV of 1.57 the git2 dependency was downgraded from 0.14.4 to 0.13.25 in [1].
This is problematic since versions prior to 0.14 are known to crash on systems with `libgit2` >=
1.4.0. Luckily git2 only raised its requirements in version 0.14.3. Thus, pin to 0.14.2 instead
of going all the way back to 0.13.x.

[1] https://github.com/termoshtt/ocipkg/pull/66