### PR TITLE
Ignore docker and podman auth info if deserialization failed

### DIFF
--- a/ocipkg/src/distribution/auth.rs
+++ b/ocipkg/src/distribution/auth.rs
@@ -25,12 +25,14 @@ impl StoredAuth {
     pub fn load_all() -> Result<Self> {
         let mut auth = StoredAuth::default();
         if let Some(path) = docker_auth_path() {
-            let new = Self::from_path(&path)?;
-            auth.append(new)?;
+            if let Ok(new) = Self::from_path(&path) {
+                auth.append(new)?;
+            }
         }
         if let Some(path) = podman_auth_path() {
-            let new = Self::from_path(&path)?;
-            auth.append(new)?;
+            if let Ok(new) = Self::from_path(&path) {
+                auth.append(new)?;
+            }
         }
         if let Some(path) = auth_path() {
             let new = Self::from_path(&path)?;


### PR DESCRIPTION
Problem
---------

For example, `$HOME/.docker/config.json` on Windows runner of GitHub Actions is following: 

```
{
	"auths": {
		"https://index.docker.io/v1/": {}
	},
	"credsStore": "wincred"
}
```

Current implementation of ocipkg will fail if this `config.json` exists with

```
Error: InvalidJson(Error("missing field `auth`", line: 3, column: 35))
```
https://github.com/rust-math/rust-mkl-container/actions/runs/3038006115/jobs/4891157780

How to fix
------------
This PR simply ignores such `config.json` which cause deserialization error.