### PR TITLE
Example with C++/cmake

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -18,11 +18,15 @@ jobs:
     - name: Add path
       run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
+    - name: Login to GitHub Container Registry
+      run: ocipkg login -u ${{ github.repository_owner }} -p ${{ github.token }} https://ghcr.io
+
     - name: Build static library
       run: |
         cd examples/cpp/lib
         cmake -Bbuild
         cmake --build build/ --target ocipkg
+        ocipkg push build/ocipkg_example_cpp_lib.tar
 
   rust-lib:
     runs-on: ubuntu-22.04

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -22,7 +22,7 @@ jobs:
       run: |
         cd examples/cpp/lib
         cmake -Bbuild
-        cmake --build build/
+        cmake --build build/ --target ocipkg
 
   rust-lib:
     runs-on: ubuntu-22.04

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -7,6 +7,23 @@ on:
   pull_request: {}
 
 jobs:
+  cpp-lib:
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions-rs/cargo@v1
+      with:
+        command: install
+        args: --path=ocipkg-cli/ -f
+    - name: Add path
+      run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+
+    - name: Build static library
+      run: |
+        cd examples/cpp/lib
+        cmake -Bbuild
+        cmake --build build/
+
   rust-lib:
     runs-on: ubuntu-22.04
     continue-on-error: true

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -26,7 +26,7 @@ jobs:
         cd examples/cpp/lib
         cmake -Bbuild
         cmake --build build/ --target ocipkg
-        ocipkg push build/ocipkg_example_cpp_lib.tar
+        ocipkg push build/ocipkg_static_cpp.tar
 
   rust-lib:
     runs-on: ubuntu-22.04

--- a/examples/cpp/lib/.gitignore
+++ b/examples/cpp/lib/.gitignore
@@ -1,0 +1,2 @@
+# cmake
+build/

--- a/examples/cpp/lib/CMakeLists.txt
+++ b/examples/cpp/lib/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.16) # default of ubuntu:20.04
-project(ocipkg_example_cpp_lib)
+project(ocipkg_static_cpp)
 
 # Build C++ source as a static library
 add_library(ocipkg_static_cpp STATIC lib.cpp)

--- a/examples/cpp/lib/CMakeLists.txt
+++ b/examples/cpp/lib/CMakeLists.txt
@@ -1,0 +1,5 @@
+cmake_minimum_required(VERSION 3.16) # default of ubuntu:20.04
+project(ocipkg_example_cpp_lib)
+add_library(ocipkg_static_cpp STATIC lib.cpp)
+install(TARGETS ocipkg_static_cpp ARCHIVE)
+include(CPack)

--- a/examples/cpp/lib/CMakeLists.txt
+++ b/examples/cpp/lib/CMakeLists.txt
@@ -15,8 +15,11 @@ if(NOT IMAGE_TAG)
   set(IMAGE_TAG "latest")
 endif()
 
-set(REGISTRY "ghcr.io/termoshtt/ocipkg/static/cpp")
-set(IMAGE_NAME "${REGISTRY}/${CMAKE_PROJECT_NAME}:${IMAGE_TAG}")
+set(REGISTRY "ghcr.io/termoshtt/ocipkg/static/cpp"
+  CACHE STRING
+  "OCI registry where the container will be pushed"
+)
+set(IMAGE_NAME "${REGISTRY}:${IMAGE_TAG}")
 
 # Call ocipkg-compose to create OCI archive
 add_custom_target(ocipkg ALL

--- a/examples/cpp/lib/CMakeLists.txt
+++ b/examples/cpp/lib/CMakeLists.txt
@@ -1,5 +1,22 @@
 cmake_minimum_required(VERSION 3.16) # default of ubuntu:20.04
 project(ocipkg_example_cpp_lib)
 add_library(ocipkg_static_cpp STATIC lib.cpp)
-install(TARGETS ocipkg_static_cpp ARCHIVE)
-include(CPack)
+
+# Get git short hash
+execute_process(
+  COMMAND "git rev-parse --short HEAD"
+  OUTPUT_VARIABLE IMAGE_TAG
+)
+if(IMAGE_TAG)
+  message("Container image tag = ${IMAGE_TAG}")
+else()
+  set(IMAGE_TAG "latest")
+endif()
+
+add_custom_target(ocipkg ALL
+  COMMAND ocipkg compose
+    -o ${CMAKE_PROJECT_NAME}.tar
+    -t ${CMAKE_PROJECT_NAME}:${IMAGE_TAG}
+    $<TARGET_FILE:ocipkg_static_cpp>
+  DEPENDS ocipkg_static_cpp
+)

--- a/examples/cpp/lib/CMakeLists.txt
+++ b/examples/cpp/lib/CMakeLists.txt
@@ -1,18 +1,23 @@
 cmake_minimum_required(VERSION 3.16) # default of ubuntu:20.04
 project(ocipkg_example_cpp_lib)
+
+# Build C++ source as a static library
 add_library(ocipkg_static_cpp STATIC lib.cpp)
 
-# Get git short hash
+# Get git short hash to use in image tag
 execute_process(
-  COMMAND "git rev-parse --short HEAD"
+  COMMAND git rev-parse --short HEAD
   OUTPUT_VARIABLE IMAGE_TAG
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
 )
 if(IMAGE_TAG)
-  message("Container image tag = ${IMAGE_TAG}")
+  message(STATUS "Git commit = ${IMAGE_TAG}")
 else()
   set(IMAGE_TAG "latest")
 endif()
 
+# Call ocipkg-compose to create OCI archive
 add_custom_target(ocipkg ALL
   COMMAND ocipkg compose
     -o ${CMAKE_PROJECT_NAME}.tar

--- a/examples/cpp/lib/CMakeLists.txt
+++ b/examples/cpp/lib/CMakeLists.txt
@@ -11,17 +11,19 @@ execute_process(
   OUTPUT_STRIP_TRAILING_WHITESPACE
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
 )
-if(IMAGE_TAG)
-  message(STATUS "Git commit = ${IMAGE_TAG}")
-else()
+if(NOT IMAGE_TAG)
   set(IMAGE_TAG "latest")
 endif()
+
+set(REGISTRY "ghcr.io/termoshtt/ocipkg/static/cpp")
+set(IMAGE_NAME "${REGISTRY}/${CMAKE_PROJECT_NAME}:${IMAGE_TAG}")
 
 # Call ocipkg-compose to create OCI archive
 add_custom_target(ocipkg ALL
   COMMAND ocipkg compose
     -o ${CMAKE_PROJECT_NAME}.tar
-    -t ${CMAKE_PROJECT_NAME}:${IMAGE_TAG}
+    -t ${IMAGE_NAME}
     $<TARGET_FILE:ocipkg_static_cpp>
   DEPENDS ocipkg_static_cpp
+  COMMENT "Creating OCI archive: ${IMAGE_NAME}"
 )

--- a/examples/cpp/lib/lib.cpp
+++ b/examples/cpp/lib/lib.cpp
@@ -1,7 +1,7 @@
 #include <iostream>
 
 extern "C" {
-  void hello_from_cpp() {
+  void ocipkg_hello_world() {
     std::cout << "Hello from C++!" << std::endl;
   }
 }

--- a/examples/cpp/lib/lib.cpp
+++ b/examples/cpp/lib/lib.cpp
@@ -1,0 +1,7 @@
+#include <iostream>
+
+extern "C" {
+  void hello_from_cpp() {
+    std::cout << "Hello from C++!" << std::endl;
+  }
+}

--- a/examples/rust/exe/build.rs
+++ b/examples/rust/exe/build.rs
@@ -1,3 +1,4 @@
 fn main() {
-    ocipkg::link_package("ghcr.io/termoshtt/ocipkg/static/rust:0dbc47b").unwrap();
+    ocipkg::link_package("ghcr.io/termoshtt/ocipkg/static/cpp:e52eae9").unwrap();
+    println!("cargo:rustc-link-lib=stdc++")
 }

--- a/ocipkg/src/distribution/mod.rs
+++ b/ocipkg/src/distribution/mod.rs
@@ -22,6 +22,7 @@ pub fn push_image(path: &Path) -> Result<()> {
     let mut f = fs::File::open(path)?;
     let mut ar = crate::image::Archive::new(&mut f);
     for (image_name, manifest) in ar.get_manifests()? {
+        log::info!("Push image: {}", image_name);
         let mut client = Client::new(image_name.registry_url()?, image_name.name)?;
         for layer in manifest.layers() {
             let digest = Digest::new(layer.digest())?;


### PR DESCRIPTION
- Build C++ library and pack into OCI archive, push to [ghcr.io/termoshtt/ocipkg/static/cpp](https://github.com/termoshtt/ocipkg/pkgs/container/ocipkg%2Fstatic%2Fcpp)
- Use C++ package in `example/rust/exe` to avoid #68 issue
  - link `libstdc++` by `build.rs` in exe example