### PR TITLE
Overwrite oci-archive file if already exists

### DIFF
--- a/ocipkg-cli/src/bin/ocipkg.rs
+++ b/ocipkg-cli/src/bin/ocipkg.rs
@@ -108,9 +108,6 @@ fn main() -> Result<()> {
         } => {
             let mut output = output;
             output.set_extension("tar");
-            if output.exists() {
-                panic!("Output already exists: {}", output.display());
-            }
             let f = fs::File::create(output)?;
             let mut b = ocipkg::image::Builder::new(f);
             if let Some(name) = tag {
@@ -135,9 +132,6 @@ fn main() -> Result<()> {
         } => {
             let mut output = output;
             output.set_extension("tar");
-            if output.exists() {
-                panic!("Output already exists: {}", output.display());
-            }
             let f = fs::File::create(output)?;
             let mut b = ocipkg::image::Builder::new(f);
             if let Some(name) = tag {


### PR DESCRIPTION
Split from #80 

Behavior Changes
----------------
- `ocipkg pack` and `ocipkg compose` command overwrites oci-archive tar file even if it already exists