### PR TITLE
`set_project_dirs` to switch the directory where containers are stored

### DIFF
--- a/ocipkg/src/error.rs
+++ b/ocipkg/src/error.rs
@@ -55,8 +55,8 @@ pub enum Error {
     //
     // System error
     //
-    #[error("No valid home directory path could be retrieved from the operating system.")]
-    NoValidHomeDirecotry,
+    #[error("Project directory is tried to set twice")]
+    ProjectDirectoryAlreadySet,
     #[error("No valid runtime directory where authentication info will be stored.")]
     NoValidRuntimeDirectory,
     #[error(transparent)]


### PR DESCRIPTION
- `ocipkg` stores containers in `${XDG_DATA_HOME}/ocipkg` set via [ProjectDirs](https://docs.rs/directories/latest/directories/struct.ProjectDirs.html)
- But this is not good when use `ocipkg` crate in other project as a thin client for OCI registries.
- This PR add a function switch it