### PR TITLE
Store Manifest JSON and blobs

### DIFF
--- a/ocipkg-cli/src/bin/ocipkg.rs
+++ b/ocipkg-cli/src/bin/ocipkg.rs
@@ -52,6 +52,8 @@ enum Opt {
     /// Get and save in local storage
     Get {
         image_name: String,
+        #[clap(short = 'f', long = "overwrite")]
+        overwrite: bool,
     },
 
     /// Push oci-archive to registry
@@ -142,9 +144,12 @@ fn main() -> Result<()> {
             ocipkg::image::load(&input)?;
         }
 
-        Opt::Get { image_name } => {
+        Opt::Get {
+            image_name,
+            overwrite,
+        } => {
             let image_name = ocipkg::ImageName::parse(&image_name)?;
-            ocipkg::distribution::get_image(&image_name)?;
+            ocipkg::distribution::get_image(&image_name, overwrite)?;
         }
 
         Opt::Push { input } => {

--- a/ocipkg/src/distribution/client.rs
+++ b/ocipkg/src/distribution/client.rs
@@ -28,6 +28,10 @@ impl Client {
         })
     }
 
+    pub fn from_image_name(image: &ImageName) -> Result<Self> {
+        Self::new(image.registry_url()?, image.name.clone())
+    }
+
     fn call(&mut self, req: ureq::Request) -> Result<ureq::Response> {
         if let Some(token) = &self.token {
             return Ok(req

--- a/ocipkg/src/distribution/mod.rs
+++ b/ocipkg/src/distribution/mod.rs
@@ -42,20 +42,51 @@ pub fn push_image(path: &Path) -> Result<()> {
 }
 
 /// Get image from registry and save it into local storage
-pub fn get_image(image_name: &ImageName) -> Result<()> {
-    let blob = get_layer_bytes(image_name, |media_type| {
-        match media_type {
-            MediaType::ImageLayerGzip => true,
-            // application/vnd.docker.image.rootfs.diff.tar.gzip case
-            MediaType::Other(ty) if ty.ends_with("tar.gzip") => true,
-            _ => false,
-        }
-    })?;
-    let buf = flate2::read::GzDecoder::new(blob.as_slice());
+pub fn get_image(image_name: &ImageName, overwrite: bool) -> Result<()> {
     let dest = crate::local::image_dir(image_name)?;
+    if dest.exists() {
+        if overwrite {
+            fs::remove_dir_all(&dest)?;
+        } else {
+            return Err(Error::ImageAlreadyExists(dest));
+        }
+    }
+    let blob_root = dest.join(".blob");
+    fs::create_dir_all(&blob_root)?;
 
-    log::info!("Get {} into {}", image_name, dest.display());
-    tar::Archive::new(buf).unpack(dest)?;
+    let mut client = Client::from_image_name(image_name)?;
+
+    log::info!("Get manifest: {}", image_name);
+    let manifest = client.get_manifest(&image_name.reference)?;
+    fs::write(
+        dest.join(".manifest.json"),
+        serde_json::to_string_pretty(&manifest)?,
+    )?;
+
+    for desc in manifest.layers() {
+        let digest = Digest::new(desc.digest())?;
+        let dest_algorithm = blob_root.join(&digest.algorithm);
+        fs::create_dir_all(&dest_algorithm)?;
+        let dest = dest_algorithm.join(&digest.encoded);
+        log::info!("Get blob: {}", digest);
+        let blob = client.get_blob(&digest)?;
+        fs::write(&dest, &blob)?;
+
+        match desc.media_type() {
+            MediaType::ImageLayerGzip => {
+                let buf = flate2::read::GzDecoder::new(blob.as_slice());
+                tar::Archive::new(buf).unpack(&dest_algorithm)?;
+            }
+            MediaType::ImageLayer => {
+                let buf = blob.as_slice();
+                tar::Archive::new(buf).unpack(&dest_algorithm)?;
+            }
+            _ => {}
+        }
+
+        let buf = flate2::read::GzDecoder::new(blob.as_slice());
+        tar::Archive::new(buf).unpack(dest)?;
+    }
 
     Ok(())
 }
@@ -65,6 +96,7 @@ pub fn get_layer_bytes(image_name: &ImageName, f: impl Fn(&MediaType) -> bool) -
     let registry_url = image_name.registry_url()?;
     let mut client = Client::new(registry_url, image_name.name.clone())?;
     let manifest = client.get_manifest(&image_name.reference)?;
+    dbg!(&manifest);
     let layer = manifest
         .layers()
         .iter()

--- a/ocipkg/src/distribution/mod.rs
+++ b/ocipkg/src/distribution/mod.rs
@@ -67,25 +67,22 @@ pub fn get_image(image_name: &ImageName, overwrite: bool) -> Result<()> {
         let digest = Digest::new(desc.digest())?;
         let dest_algorithm = blob_root.join(&digest.algorithm);
         fs::create_dir_all(&dest_algorithm)?;
-        let dest = dest_algorithm.join(&digest.encoded);
+        let blob_path = dest_algorithm.join(&digest.encoded);
         log::info!("Get blob: {}", digest);
         let blob = client.get_blob(&digest)?;
-        fs::write(&dest, &blob)?;
+        fs::write(&blob_path, &blob)?;
 
         match desc.media_type() {
             MediaType::ImageLayerGzip => {
                 let buf = flate2::read::GzDecoder::new(blob.as_slice());
-                tar::Archive::new(buf).unpack(&dest_algorithm)?;
+                tar::Archive::new(buf).unpack(&dest)?;
             }
             MediaType::ImageLayer => {
                 let buf = blob.as_slice();
-                tar::Archive::new(buf).unpack(&dest_algorithm)?;
+                tar::Archive::new(buf).unpack(&dest)?;
             }
             _ => {}
         }
-
-        let buf = flate2::read::GzDecoder::new(blob.as_slice());
-        tar::Archive::new(buf).unpack(dest)?;
     }
 
     Ok(())

--- a/ocipkg/src/error.rs
+++ b/ocipkg/src/error.rs
@@ -23,6 +23,8 @@ pub enum Error {
     NotAFile(PathBuf),
     #[error("Not a directory, or not exist: {0}")]
     NotADirectory(PathBuf),
+    #[error("Try to get already existing image: {0}")]
+    ImageAlreadyExists(PathBuf),
 
     //
     // Invalid container image

--- a/ocipkg/src/lib.rs
+++ b/ocipkg/src/lib.rs
@@ -37,7 +37,7 @@ pub fn link_package(image_name: &str) -> Result<()> {
     let image_name = ImageName::parse(image_name)?;
     let dir = local::image_dir(&image_name)?;
     if !dir.exists() {
-        distribution::get_image(&image_name)?;
+        distribution::get_image(&image_name, false)?;
     }
     println!("cargo:rustc-link-search={}", dir.display());
     for path in fs::read_dir(&dir)?.filter_map(|entry| {


### PR DESCRIPTION
Changes
-----------------
- `ocipkg get` returns error if the container is already downloaded. `ocipkg get --overwrite` option is added to remove existing. 
- `ocipkg get` store image manifest as `.manifest.json` and raw blobs where the contents are stored. For example, `ocipkg get ghcr.io/termoshtt/ocipkg/static/rust:fb58644` yields following directory. This helps managing non-`tar.gz` container including #78  and #44

```
.
├── .blob
│   └── sha256
│       └── df643e35140fb7ee1c4703b5b14ae10ab9aa7971af0a9bcf8f1212c44a14f270
├── .manifest.json
└── libocipkg_static_rust.a
```