### PR TITLE
Support oci-dir format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -474,6 +474,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
+
+[[package]]
 name = "filetime"
 version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -785,6 +791,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "tar",
+ "tempfile",
  "toml",
  "ureq",
  "url",
@@ -1141,6 +1148,18 @@ dependencies = [
  "filetime",
  "libc",
  "xattr",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "rustix",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/ocipkg/Cargo.toml
+++ b/ocipkg/Cargo.toml
@@ -33,3 +33,4 @@ walkdir = "2.5.0"
 
 [dev-dependencies]
 maplit = "1.0.2"
+tempfile = "3.10.1"

--- a/ocipkg/src/image/mod.rs
+++ b/ocipkg/src/image/mod.rs
@@ -8,6 +8,7 @@ mod artifact;
 mod config;
 mod layout;
 mod oci_archive;
+mod oci_dir;
 mod read;
 mod write;
 
@@ -15,5 +16,6 @@ pub use artifact::*;
 pub use config::*;
 pub use layout::*;
 pub use oci_archive::*;
+pub use oci_dir::*;
 pub use read::*;
 pub use write::*;

--- a/ocipkg/src/image/oci_dir.rs
+++ b/ocipkg/src/image/oci_dir.rs
@@ -1,0 +1,122 @@
+use crate::{
+    image::{ImageLayout, ImageLayoutBuilder},
+    Digest, ImageName,
+};
+use anyhow::{bail, Context, Result};
+use maplit::hashmap;
+use oci_spec::image::{
+    DescriptorBuilder, ImageIndex, ImageIndexBuilder, ImageManifest, MediaType, OciLayout,
+};
+use std::{fs, path::PathBuf};
+
+/// Build an [OciDir]
+pub struct OciDirBuilder {
+    oci_dir_root: PathBuf,
+    is_finished: bool,
+}
+
+impl Drop for OciDirBuilder {
+    fn drop(&mut self) {
+        // Remove oci-dir if it is not finished.
+        if !self.is_finished {
+            fs::remove_dir_all(&self.oci_dir_root).unwrap_or_else(|e| {
+                log::error!(
+                    "Failed to remove oci-dir {}: {}",
+                    self.oci_dir_root.display(),
+                    e
+                )
+            });
+        }
+    }
+}
+
+impl OciDirBuilder {
+    pub fn new(oci_dir_root: PathBuf) -> Result<Self> {
+        if oci_dir_root.exists() {
+            bail!("oci-dir {} already exists", oci_dir_root.display());
+        }
+        fs::create_dir_all(&oci_dir_root)?;
+        Ok(Self {
+            oci_dir_root,
+            is_finished: false,
+        })
+    }
+}
+
+impl ImageLayoutBuilder for OciDirBuilder {
+    type ImageLayout = OciDir;
+
+    fn add_blob(&mut self, data: &[u8]) -> Result<(Digest, i64)> {
+        let digest = Digest::from_buf_sha256(data);
+        let out = self.oci_dir_root.join(digest.as_path());
+        fs::create_dir_all(out.parent().unwrap())?;
+        fs::write(out, data)?;
+        Ok((digest, data.len() as i64))
+    }
+
+    fn build(mut self, manifest: ImageManifest, image_name: ImageName) -> Result<OciDir> {
+        let manifest_json = serde_json::to_string(&manifest)?;
+        let (digest, size) = self.add_blob(manifest_json.as_bytes())?;
+        let descriptor = DescriptorBuilder::default()
+            .media_type(MediaType::ImageManifest)
+            .size(size)
+            .digest(digest.to_string())
+            .annotations(hashmap! {
+                "org.opencontainers.image.ref.name".to_string() => image_name.to_string(),
+            })
+            .build()?;
+        let index = ImageIndexBuilder::default()
+            .schema_version(2_u32)
+            .manifests(vec![descriptor])
+            .build()?;
+        fs::write(
+            self.oci_dir_root.join("oci-layout"),
+            r#"{"imageLayoutVersion":"1.0.0"}"#,
+        )?;
+        fs::write(
+            self.oci_dir_root.join("index.json"),
+            serde_json::to_string(&index)?,
+        )?;
+        self.is_finished = true;
+        Ok(OciDir {
+            oci_dir_root: self.oci_dir_root.clone(),
+        })
+    }
+}
+
+/// `oci-dir` image layout, a directory in the form of [OCI Image Layout](https://github.com/opencontainers/image-spec/blob/v1.1.0/image-layout.md).
+///
+/// The name "oci-dir" comes from [`podman save`](https://docs.podman.io/en/latest/markdown/podman-save.1.html).
+pub struct OciDir {
+    oci_dir_root: PathBuf,
+}
+
+impl OciDir {
+    pub fn new(oci_dir_root: PathBuf) -> Result<Self> {
+        if !oci_dir_root.is_dir() {
+            bail!("{} is not a directory", oci_dir_root.display());
+        }
+        let oci_layout: OciLayout = fs::read(oci_dir_root.join("oci-layout"))
+            .and_then(|bytes| Ok(serde_json::from_slice(&bytes)?))
+            .context("The directory is not a oci-dir; oci-layout is not found.")?;
+        if oci_layout.image_layout_version() != "1.0.0" {
+            bail!(
+                "Incompatible oci-layout version in {}",
+                oci_dir_root.display()
+            );
+        }
+        Ok(Self { oci_dir_root })
+    }
+}
+
+impl ImageLayout for OciDir {
+    fn get_index(&mut self) -> Result<ImageIndex> {
+        let index_path = self.oci_dir_root.join("index.json");
+        let index_json = fs::read_to_string(index_path)?;
+        Ok(serde_json::from_str(&index_json)?)
+    }
+
+    fn get_blob(&mut self, digest: &Digest) -> Result<Vec<u8>> {
+        Ok(fs::read(self.oci_dir_root.join(digest.as_path()))?)
+    }
+}

--- a/ocipkg/src/image/oci_dir.rs
+++ b/ocipkg/src/image/oci_dir.rs
@@ -120,3 +120,31 @@ impl ImageLayout for OciDir {
         Ok(fs::read(self.oci_dir_root.join(digest.as_path()))?)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::image::ArtifactBuilder;
+
+    #[test]
+    fn test_artifact_over_oci_dir() -> Result<()> {
+        let tmp_dir = tempfile::tempdir()?;
+        let path = tmp_dir.path().join("oci-dir");
+        let oci_dir = OciDirBuilder::new(path)?;
+        let image_name = ImageName::parse("test")?;
+        let mut artifact = ArtifactBuilder::new(
+            oci_dir,
+            MediaType::Other("test".to_string()),
+            image_name.clone(),
+        )?
+        .build()?;
+
+        let (name, manifest) = artifact.get_manifest()?;
+        assert_eq!(name, Some(image_name));
+        assert_eq!(
+            manifest.artifact_type().as_ref().unwrap(),
+            &MediaType::Other("test".to_string())
+        );
+        Ok(())
+    }
+}


### PR DESCRIPTION
Split from #108

- Create `oci_dir.rs` in `ocipkg/src/image` to support `oci-dir` format (i.e. a directory based on image layout) with `ImageLayout` and `ImageLayoutBuilder` traits introduced in #117 