### PR TITLE
Rename `ArtifactBuilder` to `OciArtifactBuilder`, and introduce `OciArtifact`

### DIFF
--- a/ocipkg/src/image/mod.rs
+++ b/ocipkg/src/image/mod.rs
@@ -4,18 +4,18 @@
 
 pub mod annotations;
 
-mod artifact;
 mod config;
 mod layout;
 mod oci_archive;
+mod oci_artifact;
 mod oci_dir;
 mod read;
 mod write;
 
-pub use artifact::*;
 pub use config::*;
 pub use layout::*;
 pub use oci_archive::*;
+pub use oci_artifact::*;
 pub use oci_dir::*;
 pub use read::*;
 pub use write::*;

--- a/ocipkg/src/image/oci_artifact.rs
+++ b/ocipkg/src/image/oci_artifact.rs
@@ -124,7 +124,7 @@ impl<Layout: ImageLayout> OciArtifact<Layout> {
         if config_desc.media_type() == &MediaType::EmptyJSON {
             return Ok((config_desc.clone(), "{}".as_bytes().to_vec()));
         }
-        let blob = self.get_blob(&Digest::from_descriptor(&config_desc)?)?;
+        let blob = self.get_blob(&Digest::from_descriptor(config_desc)?)?;
         Ok((config_desc.clone(), blob))
     }
 
@@ -134,7 +134,7 @@ impl<Layout: ImageLayout> OciArtifact<Layout> {
             .layers()
             .iter()
             .map(|layer| {
-                let blob = self.get_blob(&Digest::from_descriptor(&layer)?)?;
+                let blob = self.get_blob(&Digest::from_descriptor(layer)?)?;
                 Ok((layer.clone(), blob))
             })
             .collect()

--- a/ocipkg/src/image/oci_artifact.rs
+++ b/ocipkg/src/image/oci_artifact.rs
@@ -80,8 +80,10 @@ impl<LayoutBuilder: ImageLayoutBuilder> OciArtifactBuilder<LayoutBuilder> {
     }
 
     /// Build the OCI Artifact
-    pub fn build(self) -> Result<LayoutBuilder::ImageLayout> {
-        self.layout.build(self.manifest, self.name)
+    pub fn build(self) -> Result<OciArtifact<LayoutBuilder::ImageLayout>> {
+        Ok(OciArtifact::new(
+            self.layout.build(self.manifest, self.name)?,
+        ))
     }
 }
 

--- a/ocipkg/src/image/oci_artifact.rs
+++ b/ocipkg/src/image/oci_artifact.rs
@@ -1,8 +1,8 @@
 use crate::{
     image::{ImageLayout, ImageLayoutBuilder},
-    ImageName,
+    Digest, ImageName,
 };
-use anyhow::Result;
+use anyhow::{Context, Result};
 use oci_spec::image::{
     Descriptor, DescriptorBuilder, ImageManifest, ImageManifestBuilder, MediaType,
 };
@@ -108,11 +108,33 @@ impl<Layout: ImageLayout> OciArtifact<Layout> {
         Self(layout)
     }
 
+    pub fn artifact_type(&mut self) -> Result<MediaType> {
+        let (_image_name, manifest) = self.get_manifest()?;
+        manifest
+            .artifact_type()
+            .clone()
+            .context("artifactType is not specified in manifest")
+    }
+
     pub fn get_config(&mut self) -> Result<(Descriptor, Vec<u8>)> {
-        todo!()
+        let (_image_name, manifest) = self.get_manifest()?;
+        let config_desc = manifest.config();
+        if config_desc.media_type() == &MediaType::EmptyJSON {
+            return Ok((config_desc.clone(), "{}".as_bytes().to_vec()));
+        }
+        let blob = self.get_blob(&Digest::from_descriptor(&config_desc)?)?;
+        Ok((config_desc.clone(), blob))
     }
 
     pub fn get_layers(&mut self) -> Result<Vec<(Descriptor, Vec<u8>)>> {
-        todo!()
+        let (_image_name, manifest) = self.get_manifest()?;
+        manifest
+            .layers()
+            .iter()
+            .map(|layer| {
+                let blob = self.get_blob(&Digest::from_descriptor(&layer)?)?;
+                Ok((layer.clone(), blob))
+            })
+            .collect()
     }
 }

--- a/ocipkg/src/image/oci_artifact.rs
+++ b/ocipkg/src/image/oci_artifact.rs
@@ -1,23 +1,30 @@
-use crate::{image::ImageLayoutBuilder, ImageName};
+use crate::{
+    image::{ImageLayout, ImageLayoutBuilder},
+    ImageName,
+};
 use anyhow::Result;
 use oci_spec::image::{
     Descriptor, DescriptorBuilder, ImageManifest, ImageManifestBuilder, MediaType,
 };
-use std::collections::HashMap;
+use std::{
+    collections::HashMap,
+    ops::{Deref, DerefMut},
+};
 
-/// Create a new OCI Artifact over [ImageLayoutBuilder]
-///
-/// This creates a generic OCI Artifact, not the ocipkg artifact defined as `application/vnd.ocipkg.v1.artifact`.
-/// It is the task of the [crate::image::Builder].
-pub struct ArtifactBuilder<Base: ImageLayoutBuilder> {
+/// Build a [OciArtifact]
+pub struct OciArtifactBuilder<LayoutBuilder: ImageLayoutBuilder> {
     name: ImageName,
     manifest: ImageManifest,
-    layout: Base,
+    layout: LayoutBuilder,
 }
 
-impl<Base: ImageLayoutBuilder> ArtifactBuilder<Base> {
+impl<LayoutBuilder: ImageLayoutBuilder> OciArtifactBuilder<LayoutBuilder> {
     /// Create a new OCI Artifact with its media type
-    pub fn new(mut layout: Base, artifact_type: MediaType, name: ImageName) -> Result<Self> {
+    pub fn new(
+        mut layout: LayoutBuilder,
+        artifact_type: MediaType,
+        name: ImageName,
+    ) -> Result<Self> {
         let empty_config = layout.add_empty_json()?;
         let manifest = ImageManifestBuilder::default()
             .schema_version(2_u32)
@@ -73,7 +80,39 @@ impl<Base: ImageLayoutBuilder> ArtifactBuilder<Base> {
     }
 
     /// Build the OCI Artifact
-    pub fn build(self) -> Result<Base::ImageLayout> {
+    pub fn build(self) -> Result<LayoutBuilder::ImageLayout> {
         self.layout.build(self.manifest, self.name)
+    }
+}
+
+/// OCI Artifact, an image layout with a image manifest which stores any type of `config` and `layers` rather than runnable container.
+///
+/// This is a thin wrapper of an actual image layout implementing [ImageLayout] to provide a common interface for OCI Artifacts.
+pub struct OciArtifact<Layout: ImageLayout>(Layout);
+
+impl<Base: ImageLayout> Deref for OciArtifact<Base> {
+    type Target = Base;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<Layout: ImageLayout> DerefMut for OciArtifact<Layout> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl<Layout: ImageLayout> OciArtifact<Layout> {
+    pub fn new(layout: Layout) -> Self {
+        Self(layout)
+    }
+
+    pub fn get_config(&mut self) -> Result<(Descriptor, Vec<u8>)> {
+        todo!()
+    }
+
+    pub fn get_layers(&mut self) -> Result<Vec<(Descriptor, Vec<u8>)>> {
+        todo!()
     }
 }

--- a/ocipkg/src/image/oci_dir.rs
+++ b/ocipkg/src/image/oci_dir.rs
@@ -145,6 +145,11 @@ mod tests {
             manifest.artifact_type().as_ref().unwrap(),
             &MediaType::Other("test".to_string())
         );
+
+        let (config_desc, config) = artifact.get_config()?;
+        assert_eq!(config_desc.media_type(), &MediaType::EmptyJSON);
+        assert_eq!(config, "{}".as_bytes());
+
         Ok(())
     }
 }

--- a/ocipkg/src/image/oci_dir.rs
+++ b/ocipkg/src/image/oci_dir.rs
@@ -124,7 +124,7 @@ impl ImageLayout for OciDir {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::image::ArtifactBuilder;
+    use crate::image::OciArtifactBuilder;
 
     #[test]
     fn test_artifact_over_oci_dir() -> Result<()> {
@@ -132,7 +132,7 @@ mod tests {
         let path = tmp_dir.path().join("oci-dir");
         let oci_dir = OciDirBuilder::new(path)?;
         let image_name = ImageName::parse("test")?;
-        let mut artifact = ArtifactBuilder::new(
+        let mut artifact = OciArtifactBuilder::new(
             oci_dir,
             MediaType::Other("test".to_string()),
             image_name.clone(),

--- a/ocipkg/src/image/write.rs
+++ b/ocipkg/src/image/write.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     digest::Digest,
-    image::{ArtifactBuilder, Config, OciArchive, OciArchiveBuilder},
+    image::{Config, OciArchive, OciArchiveBuilder, OciArtifactBuilder},
     media_types::{self, config_json},
     ImageName,
 };
@@ -17,13 +17,13 @@ use std::{
 /// Build an ocipkg artifact defined as `application/vnd.ocipkg.v1.artifact` in the oci-archive format.
 pub struct Builder {
     config: Config,
-    builder: ArtifactBuilder<OciArchiveBuilder>,
+    builder: OciArtifactBuilder<OciArchiveBuilder>,
 }
 
 impl Builder {
     pub fn new(path: PathBuf, image_name: ImageName) -> Result<Self> {
         Ok(Builder {
-            builder: ArtifactBuilder::new(
+            builder: OciArtifactBuilder::new(
                 OciArchiveBuilder::new(path)?,
                 media_types::artifact(),
                 image_name,

--- a/ocipkg/src/image/write.rs
+++ b/ocipkg/src/image/write.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     digest::Digest,
-    image::{Config, OciArchive, OciArchiveBuilder, OciArtifactBuilder},
+    image::{Config, OciArchive, OciArchiveBuilder, OciArtifact, OciArtifactBuilder},
     media_types::{self, config_json},
     ImageName,
 };
@@ -79,7 +79,7 @@ impl Builder {
         Ok(())
     }
 
-    pub fn build(mut self) -> Result<OciArchive> {
+    pub fn build(mut self) -> Result<OciArtifact<OciArchive>> {
         self.builder.add_config(
             config_json(),
             self.config.to_json()?.as_bytes(),


### PR DESCRIPTION
Split from #108 

- `ArtifactBuilder` will be used for building ocipkg artifact instead of OCI Artifact in #108 