### PR TITLE
Rename `ImageLayout` into `Image` to support remote image

### DIFF
--- a/ocipkg/src/distribution/client.rs
+++ b/ocipkg/src/distribution/client.rs
@@ -162,7 +162,7 @@ impl Client {
     /// and following `PUT` to URL obtained by `POST`.
     ///
     /// See [corresponding OCI distribution spec document](https://github.com/opencontainers/distribution-spec/blob/main/spec.md#pushing-manifests) for detail.
-    pub fn push_blob(&mut self, blob: &[u8]) -> Result<Url> {
+    pub fn push_blob(&mut self, blob: &[u8]) -> Result<(Digest, Url)> {
         let url = self
             .url
             .join(&format!("/v2/{}/blobs/uploads/", self.name))?;
@@ -186,7 +186,8 @@ impl Client {
         let loc = res
             .header("Location")
             .expect("Location header is lacked in OCI registry response");
-        Ok(Url::parse(loc).or_else(|_| self.url.join(loc))?)
+        let url = Url::parse(loc).or_else(|_| self.url.join(loc))?;
+        Ok((digest, url))
     }
 }
 

--- a/ocipkg/src/distribution/mod.rs
+++ b/ocipkg/src/distribution/mod.rs
@@ -11,34 +11,19 @@ pub use name::Name;
 pub use oci_spec::image::MediaType;
 pub use reference::Reference;
 
-use crate::{Digest, ImageName};
+use crate::{
+    image::{copy, Image, OciArchive, RemoteBuilder},
+    Digest, ImageName,
+};
 use anyhow::{bail, Result};
 use std::{fs, io::Read, path::Path};
 
 /// Push image to registry
 pub fn push_image(path: &Path) -> Result<()> {
-    if !path.is_file() {
-        bail!("{} is not a file", path.display());
-    }
-    let mut f = fs::File::open(path)?;
-    let mut ar = crate::image::Archive::new(&mut f);
-    for (image_name, manifest) in ar.get_manifests()? {
-        log::info!("Push image: {}", image_name);
-        let mut client = Client::new(image_name.registry_url()?, image_name.name)?;
-        for layer in manifest.layers() {
-            let digest = Digest::new(layer.digest())?;
-            let mut entry = ar.get_blob(&digest)?;
-            let mut buf = Vec::new();
-            entry.read_to_end(&mut buf)?;
-            client.push_blob(&buf)?;
-        }
-        let digest = Digest::new(manifest.config().digest())?;
-        let mut entry = ar.get_blob(&digest)?;
-        let mut buf = Vec::new();
-        entry.read_to_end(&mut buf)?;
-        client.push_blob(&buf)?;
-        client.push_manifest(&image_name.reference, &manifest)?;
-    }
+    let mut oci_archive = OciArchive::new(path)?;
+    let image_name = oci_archive.get_name()?;
+    let remote = RemoteBuilder::new(image_name)?;
+    copy(oci_archive, remote)?;
     Ok(())
 }
 

--- a/ocipkg/src/image/layout.rs
+++ b/ocipkg/src/image/layout.rs
@@ -1,6 +1,10 @@
-use crate::{Digest, ImageName};
+use crate::{
+    image::{OciArchive, OciDir, Remote},
+    Digest, ImageName,
+};
 use anyhow::{bail, Context, Result};
 use oci_spec::image::{Descriptor, DescriptorBuilder, ImageIndex, ImageManifest, MediaType};
+use std::path::Path;
 
 /// Handler of [OCI Image Layout] with containing single manifest and its name.
 ///
@@ -43,6 +47,54 @@ pub trait ImageBuilder {
             .digest(digest.to_string())
             .build()?)
     }
+}
+
+/// Copy image from one to another.
+pub fn copy<From: Image, To: ImageBuilder>(mut from: From, mut to: To) -> Result<To::Image> {
+    let name = from.get_name()?;
+    let manifest = from.get_manifest()?;
+    for layer in manifest.layers() {
+        let digest = Digest::from_descriptor(layer)?;
+        let blob = from.get_blob(&digest)?;
+        let (digest_new, size) = to.add_blob(&blob)?;
+        if digest != digest_new {
+            bail!("Digest of a layer in {name} mismatch: {digest} != {digest_new}",);
+        }
+        if size != layer.size() {
+            bail!(
+                "Size of a layer in {name} mismatch: {size} != {}",
+                layer.size()
+            );
+        }
+    }
+    let config = manifest.config();
+    let digest = Digest::from_descriptor(config)?;
+    let blob = from.get_blob(&digest)?;
+    let (digest_new, size) = to.add_blob(&blob)?;
+    if digest != digest_new {
+        bail!("Digest of a config in {name} mismatch: {digest} != {digest_new}",);
+    }
+    if size != config.size() {
+        bail!(
+            "Size of a config in {name} mismatch: {size} != {}",
+            config.size()
+        );
+    }
+    to.build(manifest)
+}
+
+pub fn read(name_or_path: &str) -> Result<Box<dyn Image>> {
+    let path: &Path = name_or_path.as_ref();
+    if path.is_file() {
+        return Ok(Box::new(OciArchive::new(path)?));
+    }
+    if path.is_dir() {
+        return Ok(Box::new(OciDir::new(path.to_owned())?));
+    }
+    if let Ok(image_name) = ImageName::parse(name_or_path) {
+        return Ok(Box::new(Remote::new(image_name)?));
+    }
+    bail!("Invalid image name or path: {}", name_or_path);
 }
 
 pub(crate) fn get_name_from_index(index: &ImageIndex) -> Result<ImageName> {

--- a/ocipkg/src/image/layout.rs
+++ b/ocipkg/src/image/layout.rs
@@ -26,11 +26,11 @@ pub trait Image {
 /// Creating [ImageManifest] is out of scope of this trait.
 pub trait ImageBuilder {
     /// Handler of generated image.
-    type ImageLayout: Image;
+    type Image: Image;
     /// Add a blob to the image layout.
     fn add_blob(&mut self, data: &[u8]) -> Result<(Digest, i64)>;
     /// Finish building image layout.
-    fn build(self, manifest: ImageManifest, name: ImageName) -> Result<Self::ImageLayout>;
+    fn build(self, manifest: ImageManifest, name: ImageName) -> Result<Self::Image>;
 
     /// A placeholder for `application/vnd.oci.empty.v1+json`
     fn add_empty_json(&mut self) -> Result<Descriptor> {

--- a/ocipkg/src/image/layout.rs
+++ b/ocipkg/src/image/layout.rs
@@ -27,10 +27,12 @@ pub trait Image {
 pub trait ImageBuilder {
     /// Handler of generated image.
     type Image: Image;
+
     /// Add a blob to the image layout.
     fn add_blob(&mut self, data: &[u8]) -> Result<(Digest, i64)>;
+
     /// Finish building image layout.
-    fn build(self, manifest: ImageManifest, name: ImageName) -> Result<Self::Image>;
+    fn build(self, manifest: ImageManifest) -> Result<Self::Image>;
 
     /// A placeholder for `application/vnd.oci.empty.v1+json`
     fn add_empty_json(&mut self) -> Result<Descriptor> {

--- a/ocipkg/src/image/layout.rs
+++ b/ocipkg/src/image/layout.rs
@@ -9,7 +9,7 @@ use oci_spec::image::{Descriptor, DescriptorBuilder, ImageIndex, ImageManifest, 
 ///
 /// [OCI Image Layout]: https://github.com/opencontainers/image-spec/blob/v1.1.0/image-layout.md
 ///
-pub trait ImageLayout {
+pub trait Image {
     /// Get `index.json`
     fn get_index(&mut self) -> Result<ImageIndex>;
     /// Get blob content.
@@ -41,9 +41,9 @@ pub trait ImageLayout {
 /// Create new image layout.
 ///
 /// Creating [ImageManifest] is out of scope of this trait.
-pub trait ImageLayoutBuilder {
+pub trait ImageBuilder {
     /// Handler of generated image.
-    type ImageLayout: ImageLayout;
+    type ImageLayout: Image;
     /// Add a blob to the image layout.
     fn add_blob(&mut self, data: &[u8]) -> Result<(Digest, i64)>;
     /// Finish building image layout.

--- a/ocipkg/src/image/mod.rs
+++ b/ocipkg/src/image/mod.rs
@@ -10,6 +10,7 @@ mod oci_archive;
 mod oci_artifact;
 mod oci_dir;
 mod read;
+mod remote;
 mod write;
 
 pub use config::*;
@@ -18,4 +19,5 @@ pub use oci_archive::*;
 pub use oci_artifact::*;
 pub use oci_dir::*;
 pub use read::*;
+pub use remote::*;
 pub use write::*;

--- a/ocipkg/src/image/oci_archive.rs
+++ b/ocipkg/src/image/oci_archive.rs
@@ -1,5 +1,5 @@
 use crate::{
-    image::{ImageLayout, ImageLayoutBuilder},
+    image::{Image, ImageBuilder},
     Digest, ImageName,
 };
 use anyhow::{bail, Result};
@@ -29,7 +29,7 @@ impl OciArchiveBuilder {
     }
 }
 
-impl ImageLayoutBuilder for OciArchiveBuilder {
+impl ImageBuilder for OciArchiveBuilder {
     type ImageLayout = OciArchive;
 
     fn add_blob(&mut self, blob: &[u8]) -> Result<(Digest, i64)> {
@@ -107,7 +107,7 @@ impl OciArchive {
     }
 }
 
-impl ImageLayout for OciArchive {
+impl Image for OciArchive {
     fn get_index(&mut self) -> Result<ImageIndex> {
         for entry in self.get_entries()? {
             let path = entry.path()?;

--- a/ocipkg/src/image/oci_archive.rs
+++ b/ocipkg/src/image/oci_archive.rs
@@ -30,7 +30,7 @@ impl OciArchiveBuilder {
 }
 
 impl ImageBuilder for OciArchiveBuilder {
-    type ImageLayout = OciArchive;
+    type Image = OciArchive;
 
     fn add_blob(&mut self, blob: &[u8]) -> Result<(Digest, i64)> {
         let digest = Digest::from_buf_sha256(blob);
@@ -39,7 +39,7 @@ impl ImageBuilder for OciArchiveBuilder {
         Ok((digest, blob.len() as i64))
     }
 
-    fn build(mut self, manifest: ImageManifest, name: ImageName) -> Result<Self::ImageLayout> {
+    fn build(mut self, manifest: ImageManifest, name: ImageName) -> Result<Self::Image> {
         let manifest_json = serde_json::to_string(&manifest)?;
         let (digest, size) = self.add_blob(manifest_json.as_bytes())?;
         let descriptor = DescriptorBuilder::default()

--- a/ocipkg/src/image/oci_artifact.rs
+++ b/ocipkg/src/image/oci_artifact.rs
@@ -111,7 +111,7 @@ impl<Layout: Image> OciArtifact<Layout> {
     }
 
     pub fn artifact_type(&mut self) -> Result<MediaType> {
-        let (_image_name, manifest) = self.get_manifest()?;
+        let manifest = self.get_manifest()?;
         manifest
             .artifact_type()
             .clone()
@@ -119,7 +119,7 @@ impl<Layout: Image> OciArtifact<Layout> {
     }
 
     pub fn get_config(&mut self) -> Result<(Descriptor, Vec<u8>)> {
-        let (_image_name, manifest) = self.get_manifest()?;
+        let manifest = self.get_manifest()?;
         let config_desc = manifest.config();
         if config_desc.media_type() == &MediaType::EmptyJSON {
             return Ok((config_desc.clone(), "{}".as_bytes().to_vec()));
@@ -129,7 +129,7 @@ impl<Layout: Image> OciArtifact<Layout> {
     }
 
     pub fn get_layers(&mut self) -> Result<Vec<(Descriptor, Vec<u8>)>> {
-        let (_image_name, manifest) = self.get_manifest()?;
+        let manifest = self.get_manifest()?;
         manifest
             .layers()
             .iter()

--- a/ocipkg/src/image/oci_artifact.rs
+++ b/ocipkg/src/image/oci_artifact.rs
@@ -80,7 +80,7 @@ impl<LayoutBuilder: ImageBuilder> OciArtifactBuilder<LayoutBuilder> {
     }
 
     /// Build the OCI Artifact
-    pub fn build(self) -> Result<OciArtifact<LayoutBuilder::ImageLayout>> {
+    pub fn build(self) -> Result<OciArtifact<LayoutBuilder::Image>> {
         Ok(OciArtifact::new(
             self.layout.build(self.manifest, self.name)?,
         ))

--- a/ocipkg/src/image/oci_artifact.rs
+++ b/ocipkg/src/image/oci_artifact.rs
@@ -1,5 +1,5 @@
 use crate::{
-    image::{ImageLayout, ImageLayoutBuilder},
+    image::{Image, ImageBuilder},
     Digest, ImageName,
 };
 use anyhow::{Context, Result};
@@ -12,13 +12,13 @@ use std::{
 };
 
 /// Build a [OciArtifact]
-pub struct OciArtifactBuilder<LayoutBuilder: ImageLayoutBuilder> {
+pub struct OciArtifactBuilder<LayoutBuilder: ImageBuilder> {
     name: ImageName,
     manifest: ImageManifest,
     layout: LayoutBuilder,
 }
 
-impl<LayoutBuilder: ImageLayoutBuilder> OciArtifactBuilder<LayoutBuilder> {
+impl<LayoutBuilder: ImageBuilder> OciArtifactBuilder<LayoutBuilder> {
     /// Create a new OCI Artifact with its media type
     pub fn new(
         mut layout: LayoutBuilder,
@@ -90,22 +90,22 @@ impl<LayoutBuilder: ImageLayoutBuilder> OciArtifactBuilder<LayoutBuilder> {
 /// OCI Artifact, an image layout with a image manifest which stores any type of `config` and `layers` rather than runnable container.
 ///
 /// This is a thin wrapper of an actual image layout implementing [ImageLayout] to provide a common interface for OCI Artifacts.
-pub struct OciArtifact<Layout: ImageLayout>(Layout);
+pub struct OciArtifact<Layout: Image>(Layout);
 
-impl<Base: ImageLayout> Deref for OciArtifact<Base> {
+impl<Base: Image> Deref for OciArtifact<Base> {
     type Target = Base;
     fn deref(&self) -> &Self::Target {
         &self.0
     }
 }
 
-impl<Layout: ImageLayout> DerefMut for OciArtifact<Layout> {
+impl<Layout: Image> DerefMut for OciArtifact<Layout> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0
     }
 }
 
-impl<Layout: ImageLayout> OciArtifact<Layout> {
+impl<Layout: Image> OciArtifact<Layout> {
     pub fn new(layout: Layout) -> Self {
         Self(layout)
     }

--- a/ocipkg/src/image/oci_artifact.rs
+++ b/ocipkg/src/image/oci_artifact.rs
@@ -89,7 +89,7 @@ impl<LayoutBuilder: ImageBuilder> OciArtifactBuilder<LayoutBuilder> {
 
 /// OCI Artifact, an image layout with a image manifest which stores any type of `config` and `layers` rather than runnable container.
 ///
-/// This is a thin wrapper of an actual image layout implementing [ImageLayout] to provide a common interface for OCI Artifacts.
+/// This is a thin wrapper of an actual image layout implementing [Image] to provide a common interface for OCI Artifacts.
 pub struct OciArtifact<Layout: Image>(Layout);
 
 impl<Base: Image> Deref for OciArtifact<Base> {

--- a/ocipkg/src/image/oci_artifact.rs
+++ b/ocipkg/src/image/oci_artifact.rs
@@ -1,6 +1,6 @@
 use crate::{
     image::{Image, ImageBuilder},
-    Digest, ImageName,
+    Digest,
 };
 use anyhow::{Context, Result};
 use oci_spec::image::{
@@ -13,18 +13,13 @@ use std::{
 
 /// Build a [OciArtifact]
 pub struct OciArtifactBuilder<LayoutBuilder: ImageBuilder> {
-    name: ImageName,
     manifest: ImageManifest,
     layout: LayoutBuilder,
 }
 
 impl<LayoutBuilder: ImageBuilder> OciArtifactBuilder<LayoutBuilder> {
     /// Create a new OCI Artifact with its media type
-    pub fn new(
-        mut layout: LayoutBuilder,
-        artifact_type: MediaType,
-        name: ImageName,
-    ) -> Result<Self> {
+    pub fn new(mut layout: LayoutBuilder, artifact_type: MediaType) -> Result<Self> {
         let empty_config = layout.add_empty_json()?;
         let manifest = ImageManifestBuilder::default()
             .schema_version(2_u32)
@@ -32,11 +27,7 @@ impl<LayoutBuilder: ImageBuilder> OciArtifactBuilder<LayoutBuilder> {
             .config(empty_config)
             .layers(Vec::new())
             .build()?;
-        Ok(Self {
-            layout,
-            manifest,
-            name,
-        })
+        Ok(Self { layout, manifest })
     }
 
     /// Add `config` of the OCI Artifact
@@ -81,9 +72,7 @@ impl<LayoutBuilder: ImageBuilder> OciArtifactBuilder<LayoutBuilder> {
 
     /// Build the OCI Artifact
     pub fn build(self) -> Result<OciArtifact<LayoutBuilder::Image>> {
-        Ok(OciArtifact::new(
-            self.layout.build(self.manifest, self.name)?,
-        ))
+        Ok(OciArtifact::new(self.layout.build(self.manifest)?))
     }
 }
 

--- a/ocipkg/src/image/oci_dir.rs
+++ b/ocipkg/src/image/oci_dir.rs
@@ -46,7 +46,7 @@ impl OciDirBuilder {
 }
 
 impl ImageBuilder for OciDirBuilder {
-    type ImageLayout = OciDir;
+    type Image = OciDir;
 
     fn add_blob(&mut self, data: &[u8]) -> Result<(Digest, i64)> {
         let digest = Digest::from_buf_sha256(data);

--- a/ocipkg/src/image/oci_dir.rs
+++ b/ocipkg/src/image/oci_dir.rs
@@ -1,5 +1,5 @@
 use crate::{
-    image::{ImageLayout, ImageLayoutBuilder},
+    image::{Image, ImageBuilder},
     Digest, ImageName,
 };
 use anyhow::{bail, Context, Result};
@@ -43,7 +43,7 @@ impl OciDirBuilder {
     }
 }
 
-impl ImageLayoutBuilder for OciDirBuilder {
+impl ImageBuilder for OciDirBuilder {
     type ImageLayout = OciDir;
 
     fn add_blob(&mut self, data: &[u8]) -> Result<(Digest, i64)> {
@@ -109,7 +109,7 @@ impl OciDir {
     }
 }
 
-impl ImageLayout for OciDir {
+impl Image for OciDir {
     fn get_index(&mut self) -> Result<ImageIndex> {
         let index_path = self.oci_dir_root.join("index.json");
         let index_json = fs::read_to_string(index_path)?;

--- a/ocipkg/src/image/remote.rs
+++ b/ocipkg/src/image/remote.rs
@@ -3,7 +3,7 @@ use crate::{
     image::{Image, ImageBuilder},
     Digest, ImageName,
 };
-use anyhow::{bail, Result};
+use anyhow::Result;
 use oci_spec::image::ImageManifest;
 
 /// An image stored in remote registry as [Image]
@@ -53,13 +53,11 @@ impl ImageBuilder for RemoteBuilder {
         Ok((digest, data.len() as i64))
     }
 
-    fn build(self, manifest: ImageManifest, name: ImageName) -> Result<Self::Image> {
-        if name != self.image_name {
-            bail!("Image name mismatch: {} != {}", name, self.image_name);
-        }
-        self.client.push_manifest(&name.reference, &manifest)?;
+    fn build(self, manifest: ImageManifest) -> Result<Self::Image> {
+        self.client
+            .push_manifest(&self.image_name.reference, &manifest)?;
         Ok(Remote {
-            image_name: name,
+            image_name: self.image_name,
             client: self.client,
         })
     }

--- a/ocipkg/src/image/remote.rs
+++ b/ocipkg/src/image/remote.rs
@@ -1,5 +1,9 @@
-use crate::{distribution::Client, image::Image, Digest, ImageName};
-use anyhow::Result;
+use crate::{
+    distribution::Client,
+    image::{Image, ImageBuilder},
+    Digest, ImageName,
+};
+use anyhow::{bail, Result};
 use oci_spec::image::ImageManifest;
 
 /// An image stored in remote registry as [Image]
@@ -26,5 +30,37 @@ impl Image for Remote {
 
     fn get_manifest(&mut self) -> Result<ImageManifest> {
         self.client.get_manifest(&self.image_name.reference)
+    }
+}
+
+pub struct RemoteBuilder {
+    image_name: ImageName,
+    client: Client,
+}
+
+impl RemoteBuilder {
+    pub fn new(image_name: ImageName) -> Result<Self> {
+        let client = Client::from_image_name(&image_name)?;
+        Ok(Self { image_name, client })
+    }
+}
+
+impl ImageBuilder for RemoteBuilder {
+    type Image = Remote;
+
+    fn add_blob(&mut self, data: &[u8]) -> Result<(Digest, i64)> {
+        let (digest, _url) = self.client.push_blob(data)?;
+        Ok((digest, data.len() as i64))
+    }
+
+    fn build(self, manifest: ImageManifest, name: ImageName) -> Result<Self::Image> {
+        if name != self.image_name {
+            bail!("Image name mismatch: {} != {}", name, self.image_name);
+        }
+        self.client.push_manifest(&name.reference, &manifest)?;
+        Ok(Remote {
+            image_name: name,
+            client: self.client,
+        })
     }
 }

--- a/ocipkg/src/image/remote.rs
+++ b/ocipkg/src/image/remote.rs
@@ -33,6 +33,7 @@ impl Image for Remote {
     }
 }
 
+/// Build a [Remote] image, pushing blobs and manifest to remote registry
 pub struct RemoteBuilder {
     image_name: ImageName,
     client: Client,

--- a/ocipkg/src/image/remote.rs
+++ b/ocipkg/src/image/remote.rs
@@ -2,6 +2,7 @@ use crate::{distribution::Client, image::Image, Digest, ImageName};
 use anyhow::Result;
 use oci_spec::image::ImageManifest;
 
+/// An image stored in remote registry as [Image]
 pub struct Remote {
     image_name: ImageName,
     client: Client,

--- a/ocipkg/src/image/remote.rs
+++ b/ocipkg/src/image/remote.rs
@@ -1,0 +1,29 @@
+use crate::{distribution::Client, image::Image, Digest, ImageName};
+use anyhow::Result;
+use oci_spec::image::ImageManifest;
+
+pub struct Remote {
+    image_name: ImageName,
+    client: Client,
+}
+
+impl Remote {
+    pub fn new(image_name: ImageName) -> Result<Self> {
+        let client = Client::from_image_name(&image_name)?;
+        Ok(Self { image_name, client })
+    }
+}
+
+impl Image for Remote {
+    fn get_name(&mut self) -> Result<ImageName> {
+        Ok(self.image_name.clone())
+    }
+
+    fn get_blob(&mut self, digest: &Digest) -> Result<Vec<u8>> {
+        self.client.get_blob(digest)
+    }
+
+    fn get_manifest(&mut self) -> Result<ImageManifest> {
+        self.client.get_manifest(&self.image_name.reference)
+    }
+}

--- a/ocipkg/src/image/write.rs
+++ b/ocipkg/src/image/write.rs
@@ -24,9 +24,8 @@ impl Builder {
     pub fn new(path: PathBuf, image_name: ImageName) -> Result<Self> {
         Ok(Builder {
             builder: OciArtifactBuilder::new(
-                OciArchiveBuilder::new(path)?,
+                OciArchiveBuilder::new(path, image_name)?,
                 media_types::artifact(),
-                image_name,
             )?,
             config: Config::default(),
         })

--- a/ocipkg/src/lib.rs
+++ b/ocipkg/src/lib.rs
@@ -42,7 +42,7 @@
 //! 2. Add blobs, and store their digests
 //! 3. Create a manifest using blob digests, store the manifest itself as blob, and store its digest in `index.json`
 //!
-//! This process is abstracted by [image::ImageLayoutBuilder]. This yields a layout which implements [image::ImageLayout] trait.
+//! This process is abstracted by [image::ImageBuilder]. This yields a layout which implements [image::Image] trait.
 //!
 //! [OCI Image specification]: https://github.com/opencontainers/image-spec/blob/v1.1.0/spec.md
 //! [OCI Image Manifest]: https://github.com/opencontainers/image-spec/blob/v1.1.0/manifest.md


### PR DESCRIPTION
- `Remote` and `RemoteBuilder` are added to `ocipkg::image`