### PR TITLE
Refactoring BASIC authorization

### DIFF
--- a/ocipkg-cli/src/bin/ocipkg.rs
+++ b/ocipkg-cli/src/bin/ocipkg.rs
@@ -170,7 +170,7 @@ fn main() -> Result<()> {
                 }
             }
 
-            let _token = auth.get_token(&url)?;
+            auth.try_login(&url)?;
             log::info!("Login succeed");
             auth.save()?;
         }

--- a/ocipkg-cli/src/bin/ocipkg.rs
+++ b/ocipkg-cli/src/bin/ocipkg.rs
@@ -170,7 +170,7 @@ fn main() -> Result<()> {
                 }
             }
 
-            auth.try_login(&url)?;
+            let _token = auth.get_token(&url)?;
             log::info!("Login succeed");
             auth.save()?;
         }

--- a/ocipkg/src/distribution/auth.rs
+++ b/ocipkg/src/distribution/auth.rs
@@ -65,15 +65,14 @@ impl StoredAuth {
         Ok(())
     }
 
-    /// Try login by accessing the API root `/v2/`
-    pub fn try_login(&self, url: &url::Url) -> Result<()> {
+    /// Get token by trying to access API root `/v2/`
+    pub fn get_token(&self, url: &url::Url) -> Result<Option<String>> {
         let test_url = url.join("/v2/").unwrap();
         let challenge = match ureq::get(test_url.as_str()).call() {
-            Ok(_) => return Ok(()),
+            Ok(_) => return Ok(None),
             Err(e) => AuthChallenge::try_from(e)?,
         };
-        let _token = self.challenge(&challenge).map(Some);
-        Ok(())
+        self.challenge(&challenge).map(Some)
     }
 
     /// Get token based on WWW-Authentication header

--- a/ocipkg/src/distribution/auth.rs
+++ b/ocipkg/src/distribution/auth.rs
@@ -65,13 +65,11 @@ impl StoredAuth {
         Ok(())
     }
 
-    /// Get token by trying to access API root `/v2/`
-    ///
-    /// Returns `None` if no authentication is required.
-    pub fn get_token(&self, url: &url::Url) -> Result<Option<String>> {
+    /// Try login by accessing the API root `/v2/`
+    pub fn try_login(&self, url: &url::Url) -> Result<()> {
         let test_url = url.join("/v2/").unwrap();
         let www_auth = match ureq::get(test_url.as_str()).call() {
-            Ok(_) => return Ok(None),
+            Ok(_) => return Ok(()),
             Err(ureq::Error::Status(status, res)) => {
                 if status == 401 {
                     res.header("www-authenticate").unwrap().to_string()
@@ -84,7 +82,8 @@ impl StoredAuth {
         };
 
         let challenge = AuthChallenge::from_header(&www_auth)?;
-        self.challenge(&challenge).map(Some)
+        let _token = self.challenge(&challenge).map(Some);
+        Ok(())
     }
 
     /// Get token based on WWW-Authentication header

--- a/ocipkg/src/distribution/auth.rs
+++ b/ocipkg/src/distribution/auth.rs
@@ -98,6 +98,11 @@ impl StoredAuth {
         Ok(token.token)
     }
 
+    pub fn add(&mut self, domain: &str, username: &str, password: &str) {
+        self.auths
+            .insert(domain.to_string(), Auth::new(username, password));
+    }
+
     pub fn append(&mut self, other: Self) -> Result<()> {
         for (key, value) in other.auths.into_iter() {
             if value.is_valid() {
@@ -124,6 +129,12 @@ struct Auth {
 }
 
 impl Auth {
+    fn new(username: &str, password: &str) -> Self {
+        let auth = format!("{}:{}", username, password);
+        let auth = STANDARD.encode(auth.as_bytes());
+        Self { auth }
+    }
+
     fn is_valid(&self) -> bool {
         let Ok(decoded) = STANDARD.decode(&self.auth) else {
             return false;

--- a/ocipkg/src/distribution/client.rs
+++ b/ocipkg/src/distribution/client.rs
@@ -32,6 +32,10 @@ impl Client {
         Self::new(image.registry_url()?, image.name.clone())
     }
 
+    pub fn add_basic_auth(&mut self, domain: &str, username: &str, password: &str) {
+        self.auth.add(domain, username, password);
+    }
+
     fn call(&mut self, req: ureq::Request) -> Result<ureq::Response> {
         if let Some(token) = &self.token {
             return Ok(req

--- a/ocipkg/src/distribution/client.rs
+++ b/ocipkg/src/distribution/client.rs
@@ -45,19 +45,10 @@ impl Client {
 
         // Try get token
         let try_req = req.clone();
-        let www_auth = match try_req.call() {
+        let challenge = match try_req.call() {
             Ok(res) => return Ok(res),
-            Err(ureq::Error::Status(status, res)) => {
-                if status == 401 && res.has("www-authenticate") {
-                    res.header("www-authenticate").unwrap().to_string()
-                } else {
-                    let err = res.into_json::<ErrorResponse>()?;
-                    return Err(err.into());
-                }
-            }
-            Err(ureq::Error::Transport(e)) => return Err(e.into()),
+            Err(e) => AuthChallenge::try_from(e)?,
         };
-        let challenge = AuthChallenge::from_header(&www_auth)?;
         self.token = Some(self.auth.challenge(&challenge)?);
         self.call(req)
     }


### PR DESCRIPTION
- `Client::add_basic_auth` to add additional auth info for using `ocipkg` as a library.
- Add `StoredAuth::add` which append new `username:password` pair, instead `#[deprecate]` `StoredAuth::insert` which takes base64-encoded string of the pair.
- Validate the contents of `auth.json` when loading.