### PR TITLE
Use `<name>` regex of OCI distribution spec 1.1.0, URL encoding for image name

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -795,6 +795,7 @@ dependencies = [
  "toml",
  "ureq",
  "url",
+ "urlencoding",
  "uuid",
  "walkdir",
 ]
@@ -1308,6 +1309,12 @@ dependencies = [
  "idna",
  "percent-encoding",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf8parse"

--- a/ocipkg/Cargo.toml
+++ b/ocipkg/Cargo.toml
@@ -28,6 +28,7 @@ tar = "0.4.40"
 toml = "0.8.13"
 ureq = { version = "2.9.7", features = ["json"] }
 url = "2.5.0"
+urlencoding = "2.1.3"
 uuid = { version = "1.8.0", features = ["v4"] }
 walkdir = "2.5.0"
 

--- a/ocipkg/src/distribution/name.rs
+++ b/ocipkg/src/distribution/name.rs
@@ -4,12 +4,11 @@ use std::fmt;
 
 /// Namespace of the repository
 ///
-/// In [OCI distribution spec](https://github.com/opencontainers/distribution-spec/blob/main/spec.md):
-/// > `<name>` MUST match the following regular expression:
-/// > ```text
-/// > [a-z0-9]+([._-][a-z0-9]+)*(/[a-z0-9]+([._-][a-z0-9]+)*)*
-/// > ```
-/// This struct checks this restriction at creation.
+/// The name must satisfy the following regular expression in [OCI distribution spec 1.1.0](https://github.com/opencontainers/distribution-spec/blob/v1.1.0/spec.md):
+///
+/// ```regex
+/// [a-z0-9]+((\.|_|__|-+)[a-z0-9]+)*(\/[a-z0-9]+((\.|_|__|-+)[a-z0-9]+)*)*
+/// ```
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Name(String);
 
@@ -27,7 +26,7 @@ impl fmt::Display for Name {
 }
 
 lazy_static::lazy_static! {
-    static ref NAME_RE: Regex = Regex::new(r"^[A-Za-z0-9]+([._-][A-Za-z0-9]+)*(/[A-Za-z0-9]+([._-][A-Za-z0-9]+)*)*$").unwrap();
+    static ref NAME_RE: Regex = Regex::new(r"^[a-z0-9]+((\.|_|__|-+)[a-z0-9]+)*(\/[a-z0-9]+((\.|_|__|-+)[a-z0-9]+)*)*$").unwrap();
 }
 
 impl Name {
@@ -54,5 +53,8 @@ mod tests {
         // Head must be alphanum
         assert!(Name::new("_ghcr.io").is_err());
         assert!(Name::new("/ghcr.io").is_err());
+
+        // Capital letter is not allowed
+        assert!(Name::new("ghcr.io/Termoshtt").is_err());
     }
 }

--- a/ocipkg/src/distribution/reference.rs
+++ b/ocipkg/src/distribution/reference.rs
@@ -38,6 +38,20 @@ impl Reference {
         &self.0
     }
 
+    /// Encode upper letters and `:` to URL encoding, e.g. `A` -> `%41`
+    pub fn encoded(&self) -> String {
+        self.0
+            .chars()
+            .map(|c| {
+                if c.is_ascii_uppercase() || c == ':' {
+                    format!("%{:02X}", c as u8)
+                } else {
+                    c.to_string()
+                }
+            })
+            .collect()
+    }
+
     pub fn new(name: &str) -> Result<Self> {
         if REF_RE.is_match(name) {
             Ok(Reference(name.to_string()))
@@ -63,5 +77,15 @@ mod tests {
         );
         // @ is not allowed
         assert!(Reference::new("my_super_tag@2").is_err());
+
+        // Upper ASCII is encoded
+        assert_eq!(
+            Reference::new("SuperTag").unwrap().encoded(),
+            "%53uper%54ag"
+        );
+        assert_eq!(
+            Reference::new("sha256:a1b2c3").unwrap().encoded(),
+            "sha256%3Aa1b2c3"
+        );
     }
 }

--- a/ocipkg/src/image_name.rs
+++ b/ocipkg/src/image_name.rs
@@ -197,6 +197,14 @@ impl ImageName {
         Ok(Url::parse(&url)?)
     }
 
+    pub fn as_encoded_path(&self) -> PathBuf {
+        todo!()
+    }
+
+    pub fn from_encoded_path(_path: &Path) -> Result<Self> {
+        todo!()
+    }
+
     /// Encode image name into a path by `{hostname}/{name}/__{reference}` or `{hostname}__{port}/{name}/__{reference}` if port is specified.
     pub fn as_path(&self) -> PathBuf {
         let reference = self.reference.replace(':', "__");

--- a/ocipkg/src/image_name.rs
+++ b/ocipkg/src/image_name.rs
@@ -284,19 +284,6 @@ mod test {
     use super::*;
 
     #[test]
-    fn ttlsh_style() {
-        let image_name =
-            ImageName::parse("ttl.sh/79219A62-4E86-41B3-854D-95D8F4636C9C:1h").unwrap();
-        assert_eq!(image_name.hostname, "ttl.sh".to_string(),);
-        assert_eq!(image_name.port, None);
-        assert_eq!(
-            image_name.name.as_str(),
-            "79219A62-4E86-41B3-854D-95D8F4636C9C"
-        );
-        assert_eq!(image_name.reference.as_str(), "1h")
-    }
-
-    #[test]
     fn as_path() -> Result<()> {
         fn test(name: &str, path: &Path) -> Result<()> {
             let image_name = ImageName::parse(name)?;


### PR DESCRIPTION
- Use `[a-z0-9]+((\.|_|__|-+)[a-z0-9]+)*(\/[a-z0-9]+((\.|_|__|-+)[a-z0-9]+)*)*` defined in https://github.com/opencontainers/distribution-spec/blob/v1.1.0/spec.md
- Add `ImageName::as_escaped_path` and corresponding `ImageName::from_escaped_path`.
  - In `ImageName` the reference may contains upper letters like `SuperTag`, but the filesystem of Windows and macOS does not distinguish the upper and lower letters. Thus the current implementations does not work correctly except for Linux if the reference contains upper letters.
  - These introduces new encoding based on URL encoding. An upper letter `A` is encoded into `%41` while lower letters are kept as it is.