### PR TITLE
`Client::new_with_auth` for user-created `StoredAuth`

### DIFF
--- a/ocipkg-cli/src/bin/ocipkg.rs
+++ b/ocipkg-cli/src/bin/ocipkg.rs
@@ -155,7 +155,7 @@ fn main() -> Result<()> {
             password,
         } => {
             let url = url::Url::parse(&registry)?;
-            let mut auth = ocipkg::distribution::StoredAuth::load()?;
+            let mut auth = ocipkg::distribution::StoredAuth::load().unwrap_or_default();
             match (username, password) {
                 (Some(username), Some(password)) => {
                     auth.add(

--- a/ocipkg/src/distribution/auth.rs
+++ b/ocipkg/src/distribution/auth.rs
@@ -19,17 +19,17 @@ impl StoredAuth {
 
     /// Load authentication info with docker and podman setting
     pub fn load_all() -> Result<Self> {
-        let mut auth = StoredAuth::default();
+        let mut auth = None;
         for path in [docker_auth_path(), podman_auth_path(), auth_path()]
             .into_iter()
             .filter_map(|x| x.ok())
         {
             if let Ok(new) = Self::from_path(&path) {
                 log::info!("Loaded auth info from: {}", path.display());
-                auth.append(new);
+                auth.get_or_insert_with(|| Self::default()).append(new);
             }
         }
-        Ok(auth)
+        auth.context("No valid auth info found")
     }
 
     pub fn add(&mut self, domain: &str, username: &str, password: &str) {

--- a/ocipkg/src/distribution/auth.rs
+++ b/ocipkg/src/distribution/auth.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Context, Result};
+use anyhow::{anyhow, bail, Context, Result};
 use base64::engine::{general_purpose::STANDARD, Engine};
 use oci_spec::distribution::ErrorResponse;
 use serde::{Deserialize, Serialize};
@@ -14,30 +14,20 @@ pub struct StoredAuth {
 impl StoredAuth {
     /// Load authentication info stored by ocipkg
     pub fn load() -> Result<Self> {
-        let mut auth = StoredAuth::default();
-        if let Some(path) = auth_path() {
-            let new = Self::from_path(&path)?;
-            auth.append(new)?;
-        }
-        Ok(auth)
+        Self::from_path(&auth_path()?)
     }
 
     /// Load authentication info with docker and podman setting
     pub fn load_all() -> Result<Self> {
         let mut auth = StoredAuth::default();
-        if let Some(path) = docker_auth_path() {
+        for path in [docker_auth_path(), podman_auth_path(), auth_path()]
+            .into_iter()
+            .filter_map(|x| x.ok())
+        {
             if let Ok(new) = Self::from_path(&path) {
-                auth.append(new)?;
+                log::info!("Loaded auth info from: {}", path.display());
+                auth.append(new);
             }
-        }
-        if let Some(path) = podman_auth_path() {
-            if let Ok(new) = Self::from_path(&path) {
-                auth.append(new)?;
-            }
-        }
-        if let Some(path) = auth_path() {
-            let new = Self::from_path(&path)?;
-            auth.append(new)?;
         }
         Ok(auth)
     }
@@ -94,22 +84,24 @@ impl StoredAuth {
         Ok(token.token)
     }
 
-    pub fn append(&mut self, other: Self) -> Result<()> {
+    pub fn append(&mut self, other: Self) {
         for (key, value) in other.auths.into_iter() {
             if value.is_valid() {
                 self.auths.insert(key, value);
             }
         }
-        Ok(())
     }
 
-    fn from_path(path: &Path) -> Result<Self> {
-        if path.is_file() {
-            let f = fs::File::open(path)?;
-            Ok(serde_json::from_reader(io::BufReader::new(f))?)
-        } else {
-            Ok(Self::default())
+    /// Load auth info from file
+    pub fn from_path(path: &Path) -> Result<Self> {
+        if !path.is_file() {
+            bail!("Auth file not found: {}", path.display());
         }
+        let f = fs::File::open(path)?;
+        let loaded = serde_json::from_reader(io::BufReader::new(f))?;
+        let mut out = Self::default();
+        out.append(loaded);
+        Ok(out)
     }
 }
 
@@ -134,25 +126,34 @@ impl Auth {
     }
 }
 
-fn auth_path() -> Option<PathBuf> {
-    directories::ProjectDirs::from("", "", "ocipkg")
-        .and_then(|dirs| Some(dirs.runtime_dir()?.join("auth.json")))
-        .or_else(|| {
-            // Most of container does not set XDG_RUNTIME_DIR,
-            // and then this fallback to `~/.ocipkg/config.json` like docker.
-            let dirs = directories::BaseDirs::new()?;
-            Some(dirs.home_dir().join(".ocipkg/config.json"))
-        })
+fn home_dir() -> Result<PathBuf> {
+    let dirs = directories::BaseDirs::new().context("Cannot get $HOME directory")?;
+    Ok(dirs.home_dir().to_path_buf())
 }
 
-fn docker_auth_path() -> Option<PathBuf> {
-    let dirs = directories::BaseDirs::new()?;
-    Some(dirs.home_dir().join(".docker/config.json"))
+fn auth_path() -> Result<PathBuf> {
+    let dirs = directories::ProjectDirs::from("", "", "ocipkg")
+        .context("Cannot get project directory of ocipkg")?;
+    if let Some(runtime_dir) = dirs.runtime_dir() {
+        return Ok(runtime_dir.join("auth.json"));
+    } else {
+        // Most of container does not set XDG_RUNTIME_DIR,
+        // and then this fallback to `~/.ocipkg/config.json` like docker.
+        Ok(home_dir()?.join(".ocipkg/config.json"))
+    }
 }
 
-fn podman_auth_path() -> Option<PathBuf> {
-    let dirs = directories::ProjectDirs::from("", "", "containers")?;
-    Some(dirs.runtime_dir()?.join("auth.json"))
+fn docker_auth_path() -> Result<PathBuf> {
+    Ok(home_dir()?.join(".docker/config.json"))
+}
+
+fn podman_auth_path() -> Result<PathBuf> {
+    let dirs = directories::ProjectDirs::from("", "", "containers")
+        .context("Cannot get the project directory of podman")?;
+    Ok(dirs
+        .runtime_dir()
+        .context("Cannot get runtime directory of podman")?
+        .join("auth.json"))
 }
 
 /// WWW-Authentication challenge

--- a/ocipkg/src/distribution/auth.rs
+++ b/ocipkg/src/distribution/auth.rs
@@ -26,7 +26,7 @@ impl StoredAuth {
         {
             if let Ok(new) = Self::from_path(&path) {
                 log::info!("Loaded auth info from: {}", path.display());
-                auth.get_or_insert_with(|| Self::default()).append(new);
+                auth.get_or_insert_with(Self::default).append(new);
             }
         }
         auth.context("No valid auth info found")
@@ -135,7 +135,7 @@ fn auth_path() -> Result<PathBuf> {
     let dirs = directories::ProjectDirs::from("", "", "ocipkg")
         .context("Cannot get project directory of ocipkg")?;
     if let Some(runtime_dir) = dirs.runtime_dir() {
-        return Ok(runtime_dir.join("auth.json"));
+        Ok(runtime_dir.join("auth.json"))
     } else {
         // Most of container does not set XDG_RUNTIME_DIR,
         // and then this fallback to `~/.ocipkg/config.json` like docker.

--- a/ocipkg/src/distribution/client.rs
+++ b/ocipkg/src/distribution/client.rs
@@ -19,6 +19,15 @@ pub struct Client {
 impl Client {
     pub fn new(url: Url, name: Name) -> Result<Self> {
         let auth = StoredAuth::load_all()?;
+        Self::new_with_auth(url, name, auth)
+    }
+
+    pub fn from_image_name(image: &ImageName) -> Result<Self> {
+        let auth = StoredAuth::load_all()?;
+        Self::from_image_name_with_auth(image, auth)
+    }
+
+    pub fn new_with_auth(url: Url, name: Name, auth: StoredAuth) -> Result<Self> {
         Ok(Client {
             agent: ureq::Agent::new(),
             url,
@@ -28,8 +37,8 @@ impl Client {
         })
     }
 
-    pub fn from_image_name(image: &ImageName) -> Result<Self> {
-        Self::new(image.registry_url()?, image.name.clone())
+    pub fn from_image_name_with_auth(image: &ImageName, auth: StoredAuth) -> Result<Self> {
+        Self::new_with_auth(image.registry_url()?, image.name.clone(), auth)
     }
 
     pub fn add_basic_auth(&mut self, domain: &str, username: &str, password: &str) {

--- a/ocipkg/src/distribution/client.rs
+++ b/ocipkg/src/distribution/client.rs
@@ -18,13 +18,12 @@ pub struct Client {
 
 impl Client {
     pub fn new(url: Url, name: Name) -> Result<Self> {
-        let auth = StoredAuth::load_all()?;
+        let auth = StoredAuth::load_all().unwrap_or_default();
         Self::new_with_auth(url, name, auth)
     }
 
     pub fn from_image_name(image: &ImageName) -> Result<Self> {
-        let auth = StoredAuth::load_all()?;
-        Self::from_image_name_with_auth(image, auth)
+        Self::new(image.registry_url()?, image.name.clone())
     }
 
     pub fn new_with_auth(url: Url, name: Name, auth: StoredAuth) -> Result<Self> {


### PR DESCRIPTION
- This allows `ocipkg` crate user to store own auth info