### PR TITLE
`RemoteBuilder::new_with_auth` and `add_basic_auth`

### DIFF
--- a/ocipkg/src/image/remote.rs
+++ b/ocipkg/src/image/remote.rs
@@ -1,5 +1,5 @@
 use crate::{
-    distribution::Client,
+    distribution::{Client, StoredAuth},
     image::{Image, ImageBuilder},
     Digest, ImageName,
 };
@@ -43,6 +43,15 @@ impl RemoteBuilder {
     pub fn new(image_name: ImageName) -> Result<Self> {
         let client = Client::from_image_name(&image_name)?;
         Ok(Self { image_name, client })
+    }
+
+    pub fn new_with_auth(image_name: ImageName, auth: StoredAuth) -> Result<Self> {
+        let client = Client::from_image_name_with_auth(&image_name, auth)?;
+        Ok(Self { image_name, client })
+    }
+
+    pub fn add_basic_auth(&mut self, domain: &str, username: &str, password: &str) {
+        self.client.add_basic_auth(domain, username, password);
     }
 }
 


### PR DESCRIPTION
Hot fix of #153. These methods are forwarded from `RemoteBuilder` to `Client`