### PR TITLE
Upgrading to oci-spec 0.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -884,7 +884,7 @@ dependencies = [
 
 [[package]]
 name = "ocipkg"
-version = "0.3.10"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "base16ct",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "ocipkg-cli"
-version = "0.3.10"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,7 +155,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -241,7 +241,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -422,7 +422,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -868,19 +868,18 @@ dependencies = [
 
 [[package]]
 name = "oci-spec"
-version = "0.6.8"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f5a3fe998d50101ae009351fec56d88a69f4ed182e11000e711068c2f5abf72"
+checksum = "da406e58efe2eb5986a6139626d611ce426e5324a824133d76367c765cf0b882"
 dependencies = [
  "derive_builder",
  "getset",
- "once_cell",
  "regex",
  "serde",
  "serde_json",
  "strum",
  "strum_macros",
- "thiserror",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
@@ -1030,14 +1029,14 @@ checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
  "getrandom 0.2.15",
  "libredox",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "regex"
-version = "1.10.6"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1086,7 +1085,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1296,7 +1295,7 @@ dependencies = [
  "getrandom 0.3.1",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1305,7 +1304,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
+dependencies = [
+ "thiserror-impl 2.0.11",
 ]
 
 [[package]]
@@ -1313,6 +1321,17 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1553,7 +1572,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ lazy_static = "1.5.0"
 log = "0.4.25"
 maplit = "1.0.2"
 oci-spec = "0.7.1"
-regex = "1.10.6"
+regex = "1.11.1"
 serde = { version = "1.0.217", features = ["derive"] }
 serde_json = "1.0.138"
 sha2 = "0.10.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ git2 = "0.19.0"
 lazy_static = "1.5.0"
 log = "0.4.25"
 maplit = "1.0.2"
-oci-spec = "0.6.8"
+oci-spec = "0.7.1"
 regex = "1.10.6"
 serde = { version = "1.0.217", features = ["derive"] }
 serde_json = "1.0.138"

--- a/ocipkg-cli/Cargo.toml
+++ b/ocipkg-cli/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ocipkg-cli"
 authors = ["Toshiki Teramura <toshiki.teramura@gmail.com>"]
 license = "MIT OR Apache-2.0"
-version = "0.3.10"
+version = "0.4.0"
 edition = "2021"
 description = "CLI for ocipkg"
 documentation = "https://docs.rs/ocipkg-cli"
@@ -25,7 +25,7 @@ tar.workspace = true
 url.workspace = true
 
 [dependencies.ocipkg]
-version = "0.3.10"
+version = "0.4.0"
 path = "../ocipkg"
 
 [[bin]]

--- a/ocipkg/Cargo.toml
+++ b/ocipkg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ocipkg"
-version = "0.3.10"
+version = "0.4.0"
 authors = ["Toshiki Teramura <toshiki.teramura@gmail.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/ocipkg/src/digest.rs
+++ b/ocipkg/src/digest.rs
@@ -1,107 +1,20 @@
-use anyhow::{bail, Result};
-use regex::Regex;
-use serde::{Deserialize, Serialize};
+use oci_spec::image::Digest;
 use sha2::{Digest as _, Sha256};
-use std::{fmt, path::PathBuf, str::FromStr};
+use std::{path::PathBuf, str::FromStr};
 
-/// Digest of contents
-///
-/// Digest is defined in [OCI image spec](https://github.com/opencontainers/image-spec/blob/v1.0.1/descriptor.md#digests)
-/// as a string satisfies following EBNF:
-///
-/// ```text
-/// digest                ::= algorithm ":" encoded
-/// algorithm             ::= algorithm-component (algorithm-separator algorithm-component)*
-/// algorithm-component   ::= [a-z0-9]+
-/// algorithm-separator   ::= [+._-]
-/// encoded               ::= [a-zA-Z0-9=_-]+
-/// ```
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct Digest {
-    pub algorithm: String,
-    pub encoded: String,
+pub trait DigestExt {
+    fn eval_sha256_digest(buf: &[u8]) -> Self;
+    fn as_path(&self) -> PathBuf;
 }
 
-impl From<oci_spec::image::Digest> for Digest {
-    fn from(digest: oci_spec::image::Digest) -> Self {
-        Digest {
-            algorithm: digest.algorithm().to_string(),
-            encoded: digest.digest().to_string(),
-        }
-    }
-}
-
-impl TryFrom<Digest> for oci_spec::image::Digest {
-    type Error = anyhow::Error;
-    fn try_from(digest: Digest) -> Result<Self> {
-        Ok(oci_spec::image::Digest::from_str(&digest.to_string())?)
-    }
-}
-
-lazy_static::lazy_static! {
-    static ref ENCODED_RE: Regex = Regex::new(r"[a-zA-Z0-9=_-]+").unwrap();
-}
-
-impl fmt::Display for Digest {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}:{}", self.algorithm, self.encoded)
-    }
-}
-
-impl Serialize for Digest {
-    fn serialize<S>(&self, serializer: S) -> std::prelude::v1::Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        serializer.serialize_str(&self.to_string())
-    }
-}
-
-impl<'de> Deserialize<'de> for Digest {
-    fn deserialize<D>(deserializer: D) -> std::prelude::v1::Result<Digest, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        let s = String::deserialize(deserializer)?;
-        Digest::new(&s).map_err(serde::de::Error::custom)
-    }
-}
-
-impl Digest {
-    pub fn new(input: &str) -> Result<Self> {
-        let mut iter = input.split(':');
-        match (iter.next(), iter.next(), iter.next()) {
-            (Some(algorithm), Some(encoded), None) => {
-                // FIXME: check algorithm part
-                if ENCODED_RE.is_match(encoded) {
-                    Ok(Digest {
-                        algorithm: algorithm.to_string(),
-                        encoded: encoded.to_string(),
-                    })
-                } else {
-                    bail!("Invalid digest: {}", input);
-                }
-            }
-            _ => bail!("Invalid digest: {}", input),
-        }
-    }
-
-    pub fn from_descriptor(descriptor: &oci_spec::image::Descriptor) -> Result<Self> {
-        Self::new(descriptor.digest().as_ref())
-    }
-
-    /// As a path used in oci-archive
-    pub fn as_path(&self) -> PathBuf {
-        PathBuf::from(format!("blobs/{}/{}", self.algorithm, self.encoded))
-    }
-
-    /// Calc digest using SHA-256 algorithm
-    pub fn from_buf_sha256(buf: &[u8]) -> Self {
+impl DigestExt for Digest {
+    fn eval_sha256_digest(buf: &[u8]) -> Self {
         let hash = Sha256::digest(buf);
         let digest = base16ct::lower::encode_string(&hash);
-        Self {
-            algorithm: "sha256".to_string(),
-            encoded: digest,
-        }
+        oci_spec::image::Digest::from_str(&format!("sha256:{}", digest)).unwrap()
+    }
+
+    fn as_path(&self) -> PathBuf {
+        PathBuf::from(format!("blobs/{}/{}", self.algorithm(), self.digest()))
     }
 }

--- a/ocipkg/src/digest.rs
+++ b/ocipkg/src/digest.rs
@@ -2,7 +2,7 @@ use anyhow::{bail, Result};
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest as _, Sha256};
-use std::{fmt, path::PathBuf};
+use std::{fmt, path::PathBuf, str::FromStr};
 
 /// Digest of contents
 ///
@@ -20,6 +20,22 @@ use std::{fmt, path::PathBuf};
 pub struct Digest {
     pub algorithm: String,
     pub encoded: String,
+}
+
+impl From<oci_spec::image::Digest> for Digest {
+    fn from(digest: oci_spec::image::Digest) -> Self {
+        Digest {
+            algorithm: digest.algorithm().to_string(),
+            encoded: digest.digest().to_string(),
+        }
+    }
+}
+
+impl TryFrom<&Digest> for oci_spec::image::Digest {
+    type Error = anyhow::Error;
+    fn try_from(digest: &Digest) -> Result<Self> {
+        Ok(oci_spec::image::Digest::from_str(&digest.to_string())?)
+    }
 }
 
 lazy_static::lazy_static! {

--- a/ocipkg/src/digest.rs
+++ b/ocipkg/src/digest.rs
@@ -31,9 +31,9 @@ impl From<oci_spec::image::Digest> for Digest {
     }
 }
 
-impl TryFrom<&Digest> for oci_spec::image::Digest {
+impl TryFrom<Digest> for oci_spec::image::Digest {
     type Error = anyhow::Error;
-    fn try_from(digest: &Digest) -> Result<Self> {
+    fn try_from(digest: Digest) -> Result<Self> {
         Ok(oci_spec::image::Digest::from_str(&digest.to_string())?)
     }
 }

--- a/ocipkg/src/digest.rs
+++ b/ocipkg/src/digest.rs
@@ -71,7 +71,7 @@ impl Digest {
     }
 
     pub fn from_descriptor(descriptor: &oci_spec::image::Descriptor) -> Result<Self> {
-        Self::new(descriptor.digest())
+        Self::new(descriptor.digest().as_ref())
     }
 
     /// As a path used in oci-archive

--- a/ocipkg/src/distribution/client.rs
+++ b/ocipkg/src/distribution/client.rs
@@ -1,4 +1,4 @@
-use crate::distribution::*;
+use crate::{digest::DigestExt, distribution::*};
 use anyhow::{bail, ensure, Result};
 use oci_spec::{
     distribution::TagList,
@@ -189,7 +189,7 @@ impl Client {
         };
         let url = Url::parse(loc).or_else(|_| self.url.join(loc))?;
 
-        let digest = Digest::from_buf_sha256(blob);
+        let digest = Digest::eval_sha256_digest(blob);
         let mut req = self
             .put(&url)
             .query("digest", &digest.to_string())
@@ -247,7 +247,7 @@ mod tests {
         for tag in ["tag1", "tag2", "tag3"] {
             let manifest = client.get_manifest(&Reference::new(tag)?)?;
             for layer in manifest.layers() {
-                let buf = client.get_blob(&Digest::new(layer.digest().as_ref())?)?;
+                let buf = client.get_blob(layer.digest())?;
                 dbg!(buf.len());
             }
         }

--- a/ocipkg/src/distribution/client.rs
+++ b/ocipkg/src/distribution/client.rs
@@ -1,6 +1,9 @@
 use crate::distribution::*;
 use anyhow::{bail, ensure, Result};
-use oci_spec::{distribution::*, image::*};
+use oci_spec::{
+    distribution::TagList,
+    image::{ImageManifest, ToDockerV2S2},
+};
 use url::Url;
 
 /// A client for `/v2/<name>/` API endpoint
@@ -244,7 +247,7 @@ mod tests {
         for tag in ["tag1", "tag2", "tag3"] {
             let manifest = client.get_manifest(&Reference::new(tag)?)?;
             for layer in manifest.layers() {
-                let buf = client.get_blob(&Digest::new(layer.digest())?)?;
+                let buf = client.get_blob(&Digest::new(layer.digest().as_ref())?)?;
                 dbg!(buf.len());
             }
         }

--- a/ocipkg/src/distribution/client.rs
+++ b/ocipkg/src/distribution/client.rs
@@ -135,7 +135,7 @@ impl Client {
             .join(&format!("/v2/{}/manifests/{}", self.name, reference))?;
         let mut req = self
             .put(&url)
-            .set("Content-Type", &MediaType::ImageManifest.to_string());
+            .set("Content-Type", MediaType::ImageManifest.as_ref());
         if let Some(token) = self.token.as_ref() {
             // Authorization must be done while blobs push
             req = req.set("Authorization", &format!("Bearer {}", token));
@@ -192,7 +192,7 @@ impl Client {
         let digest = Digest::eval_sha256_digest(blob);
         let mut req = self
             .put(&url)
-            .query("digest", &digest.to_string())
+            .query("digest", digest.as_ref())
             .set("Content-Length", &blob.len().to_string())
             .set("Content-Type", "application/octet-stream");
         if let Some(token) = self.token.as_ref() {

--- a/ocipkg/src/distribution/mod.rs
+++ b/ocipkg/src/distribution/mod.rs
@@ -13,9 +13,10 @@ pub use reference::Reference;
 
 use crate::{
     image::{copy, Artifact, Image, OciArchive, RemoteBuilder},
-    Digest, ImageName,
+    ImageName,
 };
 use anyhow::Result;
+use oci_spec::image::Digest;
 use std::{io::Read, path::Path};
 
 /// Push image to registry

--- a/ocipkg/src/distribution/reference.rs
+++ b/ocipkg/src/distribution/reference.rs
@@ -1,7 +1,7 @@
-use crate::Digest;
 use anyhow::{bail, Result};
+use oci_spec::image::Digest;
 use regex::Regex;
-use std::fmt;
+use std::{fmt, str::FromStr};
 
 /// Reference of container image stored in the repository
 ///
@@ -56,7 +56,7 @@ impl Reference {
         if REF_RE.is_match(name) {
             Ok(Reference(name.to_string()))
         } else if name.contains(':') {
-            _ = Digest::new(name)?;
+            _ = Digest::from_str(name)?;
             Ok(Reference(name.to_string()))
         } else {
             bail!("Invalid reference {name}");
@@ -72,8 +72,12 @@ mod tests {
     fn reference() {
         assert_eq!(Reference::new("latest").unwrap().as_str(), "latest");
         assert_eq!(
-            Reference::new("sha256:a1b2c3").unwrap().as_str(),
-            "sha256:a1b2c3"
+            Reference::new(
+                "sha256:a1b2c3d4a1b2c3d4a1b2c3d4a1b2c3d4a1b2c3d4a1b2c3d4a1b2c3d4a1b2c3d4"
+            )
+            .unwrap()
+            .as_str(),
+            "sha256:a1b2c3d4a1b2c3d4a1b2c3d4a1b2c3d4a1b2c3d4a1b2c3d4a1b2c3d4a1b2c3d4"
         );
         // @ is not allowed
         assert!(Reference::new("my_super_tag@2").is_err());
@@ -84,8 +88,12 @@ mod tests {
             "%53uper%54ag"
         );
         assert_eq!(
-            Reference::new("sha256:a1b2c3").unwrap().encoded(),
-            "sha256%3Aa1b2c3"
+            Reference::new(
+                "sha256:a1b2c3d4a1b2c3d4a1b2c3d4a1b2c3d4a1b2c3d4a1b2c3d4a1b2c3d4a1b2c3d4"
+            )
+            .unwrap()
+            .encoded(),
+            "sha256%3Aa1b2c3d4a1b2c3d4a1b2c3d4a1b2c3d4a1b2c3d4a1b2c3d4a1b2c3d4a1b2c3d4"
         );
     }
 }

--- a/ocipkg/src/image/artifact.rs
+++ b/ocipkg/src/image/artifact.rs
@@ -80,7 +80,7 @@ impl Builder {
             self.builder
                 .add_layer(media_types::layer_tar_gzip(), &buf, HashMap::new())?;
         self.config
-            .add_layer(Digest::new(layer_desc.digest())?, paths);
+            .add_layer(Digest::new(layer_desc.digest().as_ref())?, paths);
         Ok(())
     }
 

--- a/ocipkg/src/image/artifact.rs
+++ b/ocipkg/src/image/artifact.rs
@@ -1,7 +1,6 @@
 //! Compose directory as a container tar
 
 use crate::{
-    digest::Digest,
     image::{
         copy, Config, Image, OciArchive, OciArchiveBuilder, OciArtifact, OciArtifactBuilder,
         OciDir, OciDirBuilder, Remote,
@@ -59,8 +58,7 @@ impl Builder {
         let layer = self
             .builder
             .add_layer(media_types::layer_tar_gzip(), &buf, HashMap::new())?;
-        self.config
-            .add_layer(Digest::from_descriptor(&layer)?, files);
+        self.config.add_layer(layer.digest().clone(), files);
         Ok(())
     }
 
@@ -79,8 +77,7 @@ impl Builder {
         let layer_desc =
             self.builder
                 .add_layer(media_types::layer_tar_gzip(), &buf, HashMap::new())?;
-        self.config
-            .add_layer(Digest::new(layer_desc.digest().as_ref())?, paths);
+        self.config.add_layer(layer_desc.digest().clone(), paths);
         Ok(())
     }
 

--- a/ocipkg/src/image/config.rs
+++ b/ocipkg/src/image/config.rs
@@ -1,5 +1,5 @@
-use crate::Digest;
 use anyhow::Result;
+use oci_spec::image::Digest;
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, path::PathBuf};
 

--- a/ocipkg/src/image/layout.rs
+++ b/ocipkg/src/image/layout.rs
@@ -42,7 +42,6 @@ pub trait ImageBuilder {
     /// A placeholder for `application/vnd.oci.empty.v1+json`
     fn add_empty_json(&mut self) -> Result<Descriptor> {
         let (digest, size) = self.add_blob(b"{}")?;
-        let digest: oci_spec::image::Digest = digest.try_into()?;
         Ok(DescriptorBuilder::default()
             .media_type(MediaType::EmptyJSON)
             .size(size)
@@ -57,7 +56,7 @@ pub fn copy<From: Image, To: ImageBuilder>(from: &mut From, mut to: To) -> Resul
     let manifest = from.get_manifest()?;
     for layer in manifest.layers() {
         let digest = layer.digest();
-        let blob = from.get_blob(&digest)?;
+        let blob = from.get_blob(digest)?;
         let (digest_new, size) = to.add_blob(&blob)?;
         if digest != &digest_new {
             bail!("Digest of a layer in {name} mismatch: {digest} != {digest_new}",);
@@ -71,7 +70,7 @@ pub fn copy<From: Image, To: ImageBuilder>(from: &mut From, mut to: To) -> Resul
     }
     let config = manifest.config();
     let digest = config.digest();
-    let blob = from.get_blob(&digest)?;
+    let blob = from.get_blob(digest)?;
     let (digest_new, size) = to.add_blob(&blob)?;
     if digest != &digest_new {
         bail!("Digest of a config in {name} mismatch: {digest} != {digest_new}",);

--- a/ocipkg/src/image/layout.rs
+++ b/ocipkg/src/image/layout.rs
@@ -32,7 +32,7 @@ pub trait ImageBuilder {
     type Image: Image;
 
     /// Add a blob to the image layout.
-    fn add_blob(&mut self, data: &[u8]) -> Result<(Digest, i64)>;
+    fn add_blob(&mut self, data: &[u8]) -> Result<(Digest, u64)>;
 
     /// Finish building image layout.
     fn build(self, manifest: ImageManifest) -> Result<Self::Image>;

--- a/ocipkg/src/image/layout.rs
+++ b/ocipkg/src/image/layout.rs
@@ -40,10 +40,11 @@ pub trait ImageBuilder {
     /// A placeholder for `application/vnd.oci.empty.v1+json`
     fn add_empty_json(&mut self) -> Result<Descriptor> {
         let (digest, size) = self.add_blob(b"{}")?;
+        let digest: oci_spec::image::Digest = digest.try_into()?;
         Ok(DescriptorBuilder::default()
             .media_type(MediaType::EmptyJSON)
             .size(size)
-            .digest(digest.to_string())
+            .digest(digest)
             .build()?)
     }
 }

--- a/ocipkg/src/image/oci_archive.rs
+++ b/ocipkg/src/image/oci_archive.rs
@@ -63,7 +63,6 @@ impl ImageBuilder for OciArchiveBuilder {
     fn build(mut self, manifest: ImageManifest) -> Result<Self::Image> {
         let manifest_json = serde_json::to_string(&manifest)?;
         let (digest, size) = self.add_blob(manifest_json.as_bytes())?;
-        let digest: oci_spec::image::Digest = digest.try_into()?;
         let descriptor = DescriptorBuilder::default()
             .media_type(MediaType::ImageManifest)
             .size(size)
@@ -168,7 +167,7 @@ impl Image for OciArchive {
             .first()
             .context("No manifest found in index.json")?;
         let digest = desc.digest();
-        let manifest = serde_json::from_slice(self.get_blob(&digest)?.as_slice())?;
+        let manifest = serde_json::from_slice(self.get_blob(digest)?.as_slice())?;
         Ok(manifest)
     }
 }

--- a/ocipkg/src/image/oci_artifact.rs
+++ b/ocipkg/src/image/oci_artifact.rs
@@ -43,7 +43,6 @@ impl<LayoutBuilder: ImageBuilder> OciArtifactBuilder<LayoutBuilder> {
         annotations: HashMap<String, String>,
     ) -> Result<Descriptor> {
         let (digest, size) = self.layout.add_blob(config_blob)?;
-        let digest: oci_spec::image::Digest = digest.try_into()?;
         let config = DescriptorBuilder::default()
             .media_type(config_type)
             .annotations(annotations)
@@ -64,7 +63,6 @@ impl<LayoutBuilder: ImageBuilder> OciArtifactBuilder<LayoutBuilder> {
         annotations: HashMap<String, String>,
     ) -> Result<Descriptor> {
         let (digest, size) = self.layout.add_blob(layer_blob)?;
-        let digest: oci_spec::image::Digest = digest.try_into()?;
         let layer = DescriptorBuilder::default()
             .media_type(layer_type)
             .digest(digest)

--- a/ocipkg/src/image/oci_artifact.rs
+++ b/ocipkg/src/image/oci_artifact.rs
@@ -43,10 +43,11 @@ impl<LayoutBuilder: ImageBuilder> OciArtifactBuilder<LayoutBuilder> {
         annotations: HashMap<String, String>,
     ) -> Result<Descriptor> {
         let (digest, size) = self.layout.add_blob(config_blob)?;
+        let digest: oci_spec::image::Digest = digest.try_into()?;
         let config = DescriptorBuilder::default()
             .media_type(config_type)
             .annotations(annotations)
-            .digest(digest.to_string())
+            .digest(digest)
             .size(size)
             .build()?;
         self.manifest.set_config(config.clone());
@@ -63,9 +64,10 @@ impl<LayoutBuilder: ImageBuilder> OciArtifactBuilder<LayoutBuilder> {
         annotations: HashMap<String, String>,
     ) -> Result<Descriptor> {
         let (digest, size) = self.layout.add_blob(layer_blob)?;
+        let digest: oci_spec::image::Digest = digest.try_into()?;
         let layer = DescriptorBuilder::default()
             .media_type(layer_type)
-            .digest(digest.to_string())
+            .digest(digest)
             .size(size)
             .annotations(annotations)
             .build()?;

--- a/ocipkg/src/image/oci_artifact.rs
+++ b/ocipkg/src/image/oci_artifact.rs
@@ -1,6 +1,6 @@
 use crate::{
     image::{Image, ImageBuilder, OciArchive, OciDir, Remote},
-    Digest, ImageName,
+    ImageName,
 };
 use anyhow::{Context, Result};
 use chrono::{DateTime, TimeZone};
@@ -223,7 +223,7 @@ impl<Layout: Image> OciArtifact<Layout> {
         if config_desc.media_type() == &MediaType::EmptyJSON {
             return Ok((config_desc.clone(), "{}".as_bytes().to_vec()));
         }
-        let blob = self.get_blob(&Digest::from_descriptor(config_desc)?)?;
+        let blob = self.get_blob(config_desc.digest())?;
         Ok((config_desc.clone(), blob))
     }
 
@@ -233,7 +233,7 @@ impl<Layout: Image> OciArtifact<Layout> {
             .layers()
             .iter()
             .map(|layer| {
-                let blob = self.get_blob(&Digest::from_descriptor(layer)?)?;
+                let blob = self.get_blob(layer.digest())?;
                 Ok((layer.clone(), blob))
             })
             .collect()

--- a/ocipkg/src/image/oci_dir.rs
+++ b/ocipkg/src/image/oci_dir.rs
@@ -77,7 +77,6 @@ impl ImageBuilder for OciDirBuilder {
     fn build(mut self, manifest: ImageManifest) -> Result<OciDir> {
         let manifest_json = serde_json::to_string(&manifest)?;
         let (digest, size) = self.add_blob(manifest_json.as_bytes())?;
-        let digest: oci_spec::image::Digest = digest.try_into()?;
         let descriptor = DescriptorBuilder::default()
             .media_type(MediaType::ImageManifest)
             .size(size)
@@ -158,7 +157,7 @@ impl Image for OciDir {
             .first()
             .context("No manifest found in index.json")?;
         let digest = desc.digest();
-        let manifest = serde_json::from_slice(self.get_blob(&digest)?.as_slice())?;
+        let manifest = serde_json::from_slice(self.get_blob(digest)?.as_slice())?;
         Ok(manifest)
     }
 }

--- a/ocipkg/src/image/remote.rs
+++ b/ocipkg/src/image/remote.rs
@@ -67,9 +67,9 @@ impl RemoteBuilder {
 impl ImageBuilder for RemoteBuilder {
     type Image = Remote;
 
-    fn add_blob(&mut self, data: &[u8]) -> Result<(Digest, i64)> {
+    fn add_blob(&mut self, data: &[u8]) -> Result<(Digest, u64)> {
         let (digest, _url) = self.client.push_blob(data)?;
-        Ok((digest, data.len() as i64))
+        Ok((digest, data.len() as u64))
     }
 
     fn build(self, manifest: ImageManifest) -> Result<Self::Image> {

--- a/ocipkg/src/image/remote.rs
+++ b/ocipkg/src/image/remote.rs
@@ -1,10 +1,10 @@
 use crate::{
     distribution::{Client, StoredAuth},
     image::{Image, ImageBuilder},
-    Digest, ImageName,
+    ImageName,
 };
 use anyhow::Result;
-use oci_spec::image::ImageManifest;
+use oci_spec::image::{Digest, ImageManifest};
 
 /// An image stored in remote registry as [Image]
 pub struct Remote {

--- a/ocipkg/src/lib.rs
+++ b/ocipkg/src/lib.rs
@@ -58,8 +58,6 @@ pub mod media_types;
 
 mod digest;
 mod image_name;
-
-pub use digest::Digest;
 pub use image_name::ImageName;
 
 use anyhow::{Context, Result};

--- a/ocipkg/src/lib.rs
+++ b/ocipkg/src/lib.rs
@@ -58,7 +58,9 @@ pub mod media_types;
 
 mod digest;
 mod image_name;
+
 pub use image_name::ImageName;
+pub use oci_spec::image::Digest;
 
 use anyhow::{Context, Result};
 use std::fs;


### PR DESCRIPTION
- Replace `ocipkg::Digest` by `oci_spec::image::Digest`
  - This is breaking change. Bump up to 0.4.0